### PR TITLE
Tighten mypy and ruff configuration

### DIFF
--- a/changelog.d/457.misc
+++ b/changelog.d/457.misc
@@ -1,0 +1,1 @@
+Tighten mypy and ruff configuration.

--- a/mypy.ini
+++ b/mypy.ini
@@ -12,3 +12,6 @@ ignore_missing_imports = True
 
 [mypy-pywebpush]
 ignore_missing_imports = True
+
+[mypy-sygnal.apnstruncate]
+warn_return_any = False

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,6 +3,7 @@ check_untyped_defs = True
 disallow_untyped_defs = True
 show_error_codes = True
 show_traceback = True
+warn_unused_ignores = True
 
 [mypy-py_vapid]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,23 +4,8 @@ disallow_untyped_defs = True
 show_error_codes = True
 show_traceback = True
 
-[mypy-prometheus_client]
-ignore_missing_imports = True
-
 [mypy-py_vapid]
 ignore_missing_imports = True
 
 [mypy-pywebpush]
 ignore_missing_imports = True
-
-[mypy-sygnal.notifications]
-disallow_untyped_defs = False
-
-[mypy-sygnal.http]
-disallow_untyped_defs = False
-
-[mypy-sygnal.sygnal]
-disallow_untyped_defs = False
-
-[mypy-tests.testutils]
-disallow_untyped_defs = False

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,9 +1,11 @@
 [mypy]
 check_untyped_defs = True
 disallow_untyped_defs = True
+warn_no_return = True
+warn_return_any = True
+warn_unused_ignores = True
 show_error_codes = True
 show_traceback = True
-warn_unused_ignores = True
 
 [mypy-py_vapid]
 ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,9 +65,21 @@ select = [
     "F",    # pyflakes
     "W",    # pycodestyle warnings
     "I",    # isort
+    "UP",   # pyupgrade (modernize syntax for target Python version)
+    "B",    # bugbear (common bugs and design problems)
+    "C4",   # flake8-comprehensions
+    "SIM",  # flake8-simplify
+    "RUF",  # ruff-specific rules
+    "PIE",  # flake8-pie (misc lints)
+    "RSE",  # flake8-raise
+    "G",    # flake8-logging-format
+    "PERF", # perflint
+    "TC",   # flake8-type-checking
 ]
 ignore = [
-    "E501",   # line too long (handled by formatter)
+    "E501",    # line too long (handled by formatter)
+    "SIM300",  # yoda conditions (style preference)
+    "PERF203", # try-except in loop (these are intentional error handling)
 ]
 
 [tool.ruff.lint.isort]

--- a/sygnal/__init__.py
+++ b/sygnal/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2025 New Vector Ltd.
 # Copyright 2020 The Matrix.org Foundation C.I.C.
 #
@@ -8,10 +7,8 @@
 # Originally licensed under the Apache License, Version 2.0:
 # <http://www.apache.org/licenses/LICENSE-2.0>.
 
+import contextlib
 from importlib.metadata import PackageNotFoundError, version
 
-try:
+with contextlib.suppress(PackageNotFoundError):
     __version__ = version("matrix-sygnal")
-except PackageNotFoundError:
-    # package is not installed
-    pass

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2025 New Vector Ltd.
 # Copyright 2019, 2020 The Matrix.org Foundation C.I.C.
 # Copyright 2017 Vector Creations Ltd.
@@ -15,7 +14,7 @@ import copy
 import logging
 import os
 from datetime import timezone
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, ClassVar
 from uuid import uuid4
 
 import aioapns
@@ -74,9 +73,9 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
     """
 
     # Errors for which the token should be rejected and not reused
-    # See https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/handling_notification_responses_from_apns  # noqa: E501
+    # See https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/handling_notification_responses_from_apns
     # for the full list of possible errors.
-    TOKEN_ERRORS = {
+    TOKEN_ERRORS: ClassVar[set[tuple[int, str]]] = {
         # A client has uploaded an invalid token.
         (400, "BadDeviceToken"),
         # `DeviceTokenNotForTopic` may be due to a token for a different app or an
@@ -108,7 +107,7 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
         "send_badge_counts",
     } | ConcurrencyLimitedPushkin.UNDERSTOOD_CONFIG_FIELDS
 
-    APNS_PUSH_TYPES = {
+    APNS_PUSH_TYPES: ClassVar[dict[str, PushType]] = {
         "alert": PushType.ALERT,
         "background": PushType.BACKGROUND,
         "voip": PushType.VOIP,
@@ -117,7 +116,7 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
         "mdm": PushType.MDM,
     }
 
-    def __init__(self, name: str, sygnal: "Sygnal", config: Dict[str, Any]) -> None:
+    def __init__(self, name: str, sygnal: "Sygnal", config: dict[str, Any]) -> None:
         super().__init__(name, sygnal, config)
 
         nonunderstood = set(self.cfg.keys()).difference(self.UNDERSTOOD_CONFIG_FIELDS)
@@ -162,8 +161,8 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
 
         # use the Sygnal global proxy configuration
         proxy_url_str = sygnal.config.get("proxy")
-        proxy_host: Optional[str] = None
-        proxy_port: Optional[int] = None
+        proxy_host: str | None = None
+        proxy_port: int | None = None
         if proxy_url_str:
             proxy_url = decompose_http_proxy_url(proxy_url_str)
             proxy_host = proxy_url.hostname
@@ -203,7 +202,7 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
         if not push_type:
             self.push_type = None
         else:
-            if push_type not in self.APNS_PUSH_TYPES.keys():
+            if push_type not in self.APNS_PUSH_TYPES:
                 raise PushkinSetupException(f"Invalid value for push_type: {push_type}")
 
             self.push_type = self.APNS_PUSH_TYPES[push_type]
@@ -230,10 +229,10 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
         log: NotificationLoggerAdapter,
         span: Span,
         device: Device,
-        shaved_payload: Dict[str, Any],
+        shaved_payload: dict[str, Any],
         prio: int,
         notif_id: str,
-    ) -> List[str]:
+    ) -> list[str]:
         """
         Actually attempts to dispatch the notification once.
         """
@@ -255,11 +254,12 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
         )
 
         try:
-            with ACTIVE_REQUESTS_GAUGE.track_inprogress():
-                with SEND_TIME_HISTOGRAM.time():
-                    response = await self._send_notification(request)
-        except aioapns.ConnectionError:
-            raise TemporaryNotificationDispatchException("aioapns Connection Failure")
+            with ACTIVE_REQUESTS_GAUGE.track_inprogress(), SEND_TIME_HISTOGRAM.time():
+                response = await self._send_notification(request)
+        except aioapns.ConnectionError as err:
+            raise TemporaryNotificationDispatchException(
+                "aioapns Connection Failure"
+            ) from err
 
         code = int(response.status)
 
@@ -293,13 +293,13 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
 
     async def _dispatch_notification_unlimited(
         self, n: Notification, device: Device, context: NotificationContext
-    ) -> List[str]:
+    ) -> list[str]:
         log = NotificationLoggerAdapter(logger, {"request_id": context.request_id})
 
         # The pushkey is kind of secret because you can use it to send push
         # to someone.
         # span_tags = {"pushkey": device.pushkey}
-        span_tags: Dict[str, int] = {}
+        span_tags: dict[str, int] = {}
 
         with self.sygnal.tracer.start_span(
             "apns_dispatch", tags=span_tags, child_of=context.opentracing_span
@@ -321,7 +321,7 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
             send_badge_counts = self.get_config("send_badge_counts", bool, True)
 
             if n.event_id and not n.type:
-                payload: Optional[Dict[str, Any]] = self._get_payload_event_id_only(
+                payload: dict[str, Any] | None = self._get_payload_event_id_only(
                     n,
                     default_payload,
                     send_badge_counts,
@@ -390,9 +390,9 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
     def _get_payload_event_id_only(
         self,
         n: Notification,
-        default_payload: Dict[str, Any],
+        default_payload: dict[str, Any],
         send_badge_counts: bool,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Constructs a payload for a notification where we know only the event ID.
         Args:
@@ -427,7 +427,7 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
         device: Device,
         log: NotificationLoggerAdapter,
         send_badge_counts: bool,
-    ) -> Optional[Dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         """
         Constructs a payload for a notification.
         Args:
@@ -515,23 +515,22 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
 
             loc_args = [from_display]
         elif n.type == "m.room.member":
-            if n.user_is_target:
-                if n.membership == "invite":
-                    if n.room_name:
-                        loc_key = "USER_INVITE_TO_NAMED_ROOM"
-                        loc_args = [
-                            from_display,
-                            n.room_name[0 : self.MAX_FIELD_LENGTH],
-                        ]
-                    elif n.room_alias:
-                        loc_key = "USER_INVITE_TO_NAMED_ROOM"
-                        loc_args = [
-                            from_display,
-                            n.room_alias[0 : self.MAX_FIELD_LENGTH],
-                        ]
-                    else:
-                        loc_key = "USER_INVITE_TO_CHAT"
-                        loc_args = [from_display]
+            if n.user_is_target and n.membership == "invite":
+                if n.room_name:
+                    loc_key = "USER_INVITE_TO_NAMED_ROOM"
+                    loc_args = [
+                        from_display,
+                        n.room_name[0 : self.MAX_FIELD_LENGTH],
+                    ]
+                elif n.room_alias:
+                    loc_key = "USER_INVITE_TO_NAMED_ROOM"
+                    loc_args = [
+                        from_display,
+                        n.room_alias[0 : self.MAX_FIELD_LENGTH],
+                    ]
+                else:
+                    loc_key = "USER_INVITE_TO_CHAT"
+                    loc_args = [from_display]
         elif n.type:
             # A type of message was received that we don't know about
             # but it was important enough for a push to have got to us

--- a/sygnal/apnstruncate.py
+++ b/sygnal/apnstruncate.py
@@ -10,20 +10,14 @@
 # Copied and adapted from
 # https://raw.githubusercontent.com/matrix-org/pushbaby/master/pushbaby/truncate.py
 import json
-import sys
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Literal
 
-if TYPE_CHECKING or sys.version_info < (3, 8, 0):
-    from typing_extensions import Literal
-else:
-    from typing import Literal
-
-Choppable = Union[
-    Tuple[Literal["alert", "alert.body"]], Tuple[Literal["alert.loc-args"], int]
-]
+Choppable = (
+    tuple[Literal["alert", "alert.body"]] | tuple[Literal["alert.loc-args"], int]
+)
 
 
-def json_encode(payload: Dict[str, Any]) -> bytes:
+def json_encode(payload: dict[str, Any]) -> bytes:
     return json.dumps(payload, ensure_ascii=False).encode()
 
 
@@ -31,7 +25,7 @@ class BodyTooLongException(Exception):
     pass
 
 
-def is_too_long(payload: Dict[Any, Any], max_length: int = 2048) -> bool:
+def is_too_long(payload: dict[Any, Any], max_length: int = 2048) -> bool:
     """
     Returns True if the given payload dictionary is too long for a push.
     Note that the maximum is now 2kB "In iOS 8 and later" although in
@@ -43,7 +37,7 @@ def is_too_long(payload: Dict[Any, Any], max_length: int = 2048) -> bool:
     return len(json_encode(payload)) > max_length
 
 
-def truncate(payload: Dict[str, Any], max_length: int = 2048) -> Dict[str, Any]:
+def truncate(payload: dict[str, Any], max_length: int = 2048) -> dict[str, Any]:
     """
     Truncate APNs fields to make the payload fit within the max length
     specified.
@@ -61,7 +55,7 @@ def truncate(payload: Dict[str, Any], max_length: int = 2048) -> Dict[str, Any]:
     payload = payload.copy()
     if "aps" not in payload:
         if is_too_long(payload, max_length):
-            raise BodyTooLongException()
+            raise BodyTooLongException
         else:
             return payload
     aps = payload["aps"]
@@ -78,7 +72,7 @@ def truncate(payload: Dict[str, Any], max_length: int = 2048) -> Dict[str, Any]:
     while is_too_long(payload, max_length):
         longest = _longest_choppable(aps)
         if longest is None:
-            raise BodyTooLongException()
+            raise BodyTooLongException
 
         txt = _choppable_get(aps, longest)
         # Note that python's support for this is actually broken on some OSes
@@ -90,8 +84,8 @@ def truncate(payload: Dict[str, Any], max_length: int = 2048) -> Dict[str, Any]:
     return payload
 
 
-def _choppables_for_aps(aps: Dict[str, Any]) -> List[Choppable]:
-    ret: List[Choppable] = []
+def _choppables_for_aps(aps: dict[str, Any]) -> list[Choppable]:
+    ret: list[Choppable] = []
     if "alert" not in aps:
         return ret
 
@@ -108,23 +102,20 @@ def _choppables_for_aps(aps: Dict[str, Any]) -> List[Choppable]:
 
 
 def _choppable_get(
-    aps: Dict[str, Any],
+    aps: dict[str, Any],
     choppable: Choppable,
 ) -> str:
-    result: str
     if choppable[0] == "alert":
-        result = aps["alert"]
+        return aps["alert"]
     elif choppable[0] == "alert.body":
-        result = aps["alert"]["body"]
+        return aps["alert"]["body"]
     elif choppable[0] == "alert.loc-args":
-        result = aps["alert"]["loc-args"][choppable[1]]
-    else:
-        raise ValueError(f"Unknown choppable: {choppable[0]}")
-    return result
+        return aps["alert"]["loc-args"][choppable[1]]
+    raise ValueError(f"Unknown choppable: {choppable[0]}")
 
 
 def _choppable_put(
-    aps: Dict[str, Any],
+    aps: dict[str, Any],
     choppable: Choppable,
     val: str,
 ) -> None:
@@ -136,7 +127,7 @@ def _choppable_put(
         aps["alert"]["loc-args"][choppable[1]] = val
 
 
-def _longest_choppable(aps: Dict[str, Any]) -> Optional[Choppable]:
+def _longest_choppable(aps: dict[str, Any]) -> Choppable | None:
     longest = None
     length_of_longest = 0
     for c in _choppables_for_aps(aps):

--- a/sygnal/apnstruncate.py
+++ b/sygnal/apnstruncate.py
@@ -111,12 +111,16 @@ def _choppable_get(
     aps: Dict[str, Any],
     choppable: Choppable,
 ) -> str:
+    result: str
     if choppable[0] == "alert":
-        return aps["alert"]
+        result = aps["alert"]
     elif choppable[0] == "alert.body":
-        return aps["alert"]["body"]
+        result = aps["alert"]["body"]
     elif choppable[0] == "alert.loc-args":
-        return aps["alert"]["loc-args"][choppable[1]]
+        result = aps["alert"]["loc-args"][choppable[1]]
+    else:
+        raise ValueError(f"Unknown choppable: {choppable[0]}")
+    return result
 
 
 def _choppable_put(

--- a/sygnal/exceptions.py
+++ b/sygnal/exceptions.py
@@ -41,11 +41,3 @@ class NotificationQuotaDispatchException(Exception):
     def __init__(self, *args: object, custom_retry_delay: int | None = None) -> None:
         super().__init__(*args)
         self.custom_retry_delay = custom_retry_delay
-
-
-class ProxyConnectError(ConnectionError):
-    """
-    Exception raised when we are unable to start a connection using a HTTP proxy
-    This indicates an issue with the HTTP Proxy in use rather than the final
-    endpoint we wanted to contact.
-    """

--- a/sygnal/exceptions.py
+++ b/sygnal/exceptions.py
@@ -6,7 +6,6 @@
 #
 # Originally licensed under the Apache License, Version 2.0:
 # <http://www.apache.org/licenses/LICENSE-2.0>.
-from typing import Optional
 
 
 class InvalidNotificationException(Exception):
@@ -27,7 +26,7 @@ class TemporaryNotificationDispatchException(Exception):
     hopefully temporary, so the request should possibly be retried soon.
     """
 
-    def __init__(self, *args: object, custom_retry_delay: Optional[int] = None) -> None:
+    def __init__(self, *args: object, custom_retry_delay: int | None = None) -> None:
         super().__init__(*args)
         self.custom_retry_delay = custom_retry_delay
 
@@ -39,7 +38,7 @@ class NotificationQuotaDispatchException(Exception):
     retried soon.
     """
 
-    def __init__(self, *args: object, custom_retry_delay: Optional[int] = None) -> None:
+    def __init__(self, *args: object, custom_retry_delay: int | None = None) -> None:
         super().__init__(*args)
         self.custom_retry_delay = custom_retry_delay
 
@@ -50,5 +49,3 @@ class ProxyConnectError(ConnectionError):
     This indicates an issue with the HTTP Proxy in use rather than the final
     endpoint we wanted to contact.
     """
-
-    pass

--- a/sygnal/helper/proxy/__init__.py
+++ b/sygnal/helper/proxy/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2025 New Vector Ltd.
 # Copyright 2020 The Matrix.org Foundation C.I.C.
 #
@@ -7,7 +6,7 @@
 #
 # Originally licensed under the Apache License, Version 2.0:
 # <http://www.apache.org/licenses/LICENSE-2.0>.
-from typing import NamedTuple, Optional, Tuple
+from typing import NamedTuple
 from urllib.parse import urlparse
 
 """
@@ -17,10 +16,12 @@ from urllib.parse import urlparse
     port is always an integer; a default port number used if necessary.
     credentials is None or a tuple of (username, password) strings.
 """
-HttpProxyUrl = NamedTuple(
-    "HttpProxyUrl",
-    [("hostname", str), ("port", int), ("credentials", Optional[Tuple[str, str]])],
-)
+
+
+class HttpProxyUrl(NamedTuple):
+    hostname: str
+    port: int
+    credentials: tuple[str, str] | None
 
 
 def decompose_http_proxy_url(proxy_url: str) -> HttpProxyUrl:

--- a/sygnal/http.py
+++ b/sygnal/http.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2019-2025 New Vector Ltd.
 # Copyright 2019 The Matrix.org Foundation C.I.C.
 # Copyright 2014 OpenMarket Ltd.
@@ -13,8 +12,9 @@ import logging
 import sys
 import time
 import traceback
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Awaitable, Callable, List
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from aiohttp import web
@@ -76,7 +76,7 @@ def _make_request_id() -> str:
     return str(uuid4())
 
 
-def find_pushkins(sygnal: "Sygnal", appid: str) -> List[Pushkin]:
+def find_pushkins(sygnal: "Sygnal", appid: str) -> list[Pushkin]:
     """Finds matching pushkins according to the appid.
 
     Args:
@@ -153,7 +153,7 @@ async def _handle_dispatch(
         return web.Response(status=502)
     except Exception:
         status_code = 500
-        log.error("Exception whilst dispatching notification.", exc_info=True)
+        log.exception("Exception whilst dispatching notification.")
         return web.Response(status=500)
     finally:
         PUSHGATEWAY_HTTP_RESPONSES_COUNTER.labels(code=status_code).inc()
@@ -169,10 +169,10 @@ async def _handle_dispatch(
 
 async def handle_notify(request: web.Request) -> web.Response:
     """Handle POST /_matrix/push/v1/notify."""
-    sygnal: "Sygnal" = request.app["sygnal"]
+    sygnal: Sygnal = request.app["sygnal"]
 
     request_id = _make_request_id()
-    header_dict = {k: v for k, v in request.headers.items()}
+    header_dict = dict(request.headers.items())
 
     # extract OpenTracing scope from the HTTP headers
     span_ctx = sygnal.tracer.extract(Format.HTTP_HEADERS, header_dict)

--- a/sygnal/notifications.py
+++ b/sygnal/notifications.py
@@ -42,9 +42,10 @@ def get_key(
 ) -> Optional[T]:
     if key not in raw:
         return default
-    if not isinstance(raw[key], type_):
+    value = raw[key]
+    if not isinstance(value, type_):
         raise InvalidNotificationException(f"{key} is of invalid type")
-    return raw[key]
+    return value
 
 
 class Tweaks:
@@ -122,12 +123,13 @@ class Pushkin(abc.ABC):
     ) -> Optional[T]:
         if key not in self.cfg:
             return default
-        if not isinstance(self.cfg[key], type_):
+        value = self.cfg[key]
+        if not isinstance(value, type_):
             raise PushkinSetupException(
                 f"{key} is of incorrect type, please check that the entry for {key} is "
                 f"formatted correctly in the config file. "
             )
-        return self.cfg[key]
+        return value
 
     def handles_appid(self, appid: str) -> bool:
         """Checks whether the pushkin is responsible for the given app ID"""

--- a/sygnal/notifications.py
+++ b/sygnal/notifications.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2019-2025 New Vector Ltd.
 # Copyright 2019 The Matrix.org Foundation C.I.C.
 # Copyright 2014 OpenMarket Ltd.
@@ -9,7 +8,7 @@
 # Originally licensed under the Apache License, Version 2.0:
 # <http://www.apache.org/licenses/LICENSE-2.0>.
 import abc
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, TypeVar, overload
+from typing import TYPE_CHECKING, Any, ClassVar, TypeVar, overload
 
 from matrix_common.regex import glob_to_regex
 from opentracing import Span
@@ -28,18 +27,18 @@ T = TypeVar("T")
 
 
 @overload
-def get_key(raw: Dict[str, Any], key: str, type_: Type[T], default: T) -> T: ...
+def get_key(raw: dict[str, Any], key: str, type_: type[T], default: T) -> T: ...
 
 
 @overload
 def get_key(
-    raw: Dict[str, Any], key: str, type_: Type[T], default: None = None
-) -> Optional[T]: ...
+    raw: dict[str, Any], key: str, type_: type[T], default: None = None
+) -> T | None: ...
 
 
 def get_key(
-    raw: Dict[str, Any], key: str, type_: Type[T], default: Optional[T] = None
-) -> Optional[T]:
+    raw: dict[str, Any], key: str, type_: type[T], default: T | None = None
+) -> T | None:
     if key not in raw:
         return default
     value = raw[key]
@@ -49,12 +48,12 @@ def get_key(
 
 
 class Tweaks:
-    def __init__(self, raw: Dict[str, Any]):
-        self.sound: Optional[str] = get_key(raw, "sound", str)
+    def __init__(self, raw: dict[str, Any]):
+        self.sound: str | None = get_key(raw, "sound", str)
 
 
 class Device:
-    def __init__(self, raw: Dict[str, Any]):
+    def __init__(self, raw: dict[str, Any]):
         if "app_id" not in raw or not isinstance(raw["app_id"], str):
             raise InvalidNotificationException(
                 "Device with missing or non-string app_id"
@@ -67,30 +66,30 @@ class Device:
         self.pushkey: str = raw["pushkey"]
 
         self.pushkey_ts: int = get_key(raw, "pushkey_ts", int, 0)
-        self.data: Optional[Dict[str, Any]] = get_key(raw, "data", dict)
+        self.data: dict[str, Any] | None = get_key(raw, "data", dict)
         self.tweaks = Tweaks(get_key(raw, "tweaks", dict, {}))
 
 
 class Counts:
-    def __init__(self, raw: Dict[str, Any]):
-        self.unread: Optional[int] = get_key(raw, "unread", int)
-        self.missed_calls: Optional[int] = get_key(raw, "missed_calls", int)
+    def __init__(self, raw: dict[str, Any]):
+        self.unread: int | None = get_key(raw, "unread", int)
+        self.missed_calls: int | None = get_key(raw, "missed_calls", int)
 
 
 class Notification:
     def __init__(self, notif: dict):
         # optional attributes
-        self.room_name: Optional[str] = notif.get("room_name")
-        self.room_alias: Optional[str] = notif.get("room_alias")
-        self.prio: Optional[str] = notif.get("prio")
-        self.membership: Optional[str] = notif.get("membership")
-        self.sender_display_name: Optional[str] = notif.get("sender_display_name")
-        self.content: Optional[Dict[str, Any]] = notif.get("content")
-        self.event_id: Optional[str] = notif.get("event_id")
-        self.room_id: Optional[str] = notif.get("room_id")
-        self.user_is_target: Optional[bool] = notif.get("user_is_target")
-        self.type: Optional[str] = notif.get("type")
-        self.sender: Optional[str] = notif.get("sender")
+        self.room_name: str | None = notif.get("room_name")
+        self.room_alias: str | None = notif.get("room_alias")
+        self.prio: str | None = notif.get("prio")
+        self.membership: str | None = notif.get("membership")
+        self.sender_display_name: str | None = notif.get("sender_display_name")
+        self.content: dict[str, Any] | None = notif.get("content")
+        self.event_id: str | None = notif.get("event_id")
+        self.room_id: str | None = notif.get("room_id")
+        self.user_is_target: bool | None = notif.get("user_is_target")
+        self.type: str | None = notif.get("type")
+        self.sender: str | None = notif.get("sender")
 
         if "devices" not in notif or not isinstance(notif["devices"], list):
             raise InvalidNotificationException("Expected list in 'devices' key")
@@ -104,23 +103,23 @@ class Notification:
 
 
 class Pushkin(abc.ABC):
-    def __init__(self, name: str, sygnal: "Sygnal", config: Dict[str, Any]):
+    def __init__(self, name: str, sygnal: "Sygnal", config: dict[str, Any]):
         self.name = name
         self.appid_pattern = glob_to_regex(name, ignore_case=False)
         self.cfg = config
         self.sygnal = sygnal
 
     @overload
-    def get_config(self, key: str, type_: Type[T], default: T) -> T: ...
+    def get_config(self, key: str, type_: type[T], default: T) -> T: ...
 
     @overload
     def get_config(
-        self, key: str, type_: Type[T], default: None = None
-    ) -> Optional[T]: ...
+        self, key: str, type_: type[T], default: None = None
+    ) -> T | None: ...
 
     def get_config(
-        self, key: str, type_: Type[T], default: Optional[T] = None
-    ) -> Optional[T]:
+        self, key: str, type_: type[T], default: T | None = None
+    ) -> T | None:
         if key not in self.cfg:
             return default
         value = self.cfg[key]
@@ -138,7 +137,7 @@ class Pushkin(abc.ABC):
     @abc.abstractmethod
     async def dispatch_notification(
         self, n: Notification, device: Device, context: "NotificationContext"
-    ) -> List[str]:
+    ) -> list[str]:
         """
         Args:
             n: The notification to dispatch via this pushkin
@@ -150,13 +149,12 @@ class Pushkin(abc.ABC):
         """
         ...
 
-    async def close(self) -> None:
+    async def close(self) -> None:  # noqa: B027
         """Clean up resources held by this pushkin. Called during shutdown."""
-        pass
 
     @classmethod
     async def create(
-        cls, name: str, sygnal: "Sygnal", config: Dict[str, Any]
+        cls, name: str, sygnal: "Sygnal", config: dict[str, Any]
     ) -> "Pushkin":
         """
         Override this if your pushkin needs to call async code in order to
@@ -179,7 +177,7 @@ class ConcurrencyLimitedPushkin(Pushkin):
     # We start turning away requests after this limit is reached.
     DEFAULT_CONCURRENCY_LIMIT = 512
 
-    UNDERSTOOD_CONFIG_FIELDS = {"inflight_request_limit"}
+    UNDERSTOOD_CONFIG_FIELDS: ClassVar[set[str]] = {"inflight_request_limit"}
 
     RATELIMITING_DROPPED_REQUESTS = Counter(
         "sygnal_inflight_request_limit_drop",
@@ -188,7 +186,7 @@ class ConcurrencyLimitedPushkin(Pushkin):
         labelnames=["pushkin"],
     )
 
-    def __init__(self, name: str, sygnal: "Sygnal", config: Dict[str, Any]):
+    def __init__(self, name: str, sygnal: "Sygnal", config: dict[str, Any]):
         super().__init__(name, sygnal, config)
         self._concurrent_limit = config.get(
             "inflight_request_limit",
@@ -204,7 +202,7 @@ class ConcurrencyLimitedPushkin(Pushkin):
 
     async def dispatch_notification(
         self, n: Notification, device: Device, context: "NotificationContext"
-    ) -> List[str]:
+    ) -> list[str]:
         if self._concurrent_now >= self._concurrent_limit:
             self.dropped_requests_counter.inc()
             raise NotificationDispatchException(
@@ -220,12 +218,12 @@ class ConcurrencyLimitedPushkin(Pushkin):
 
     async def _dispatch_notification_unlimited(
         self, n: Notification, device: Device, context: "NotificationContext"
-    ) -> List[str]:
+    ) -> list[str]:
         # to be overridden by Pushkins!
         raise NotImplementedError
 
 
-class NotificationContext(object):
+class NotificationContext:
     def __init__(self, request_id: str, opentracing_span: Span, start_time: float):
         """
         Args:

--- a/sygnal/notifications.py
+++ b/sygnal/notifications.py
@@ -153,7 +153,9 @@ class Pushkin(abc.ABC):
         pass
 
     @classmethod
-    async def create(cls, name: str, sygnal: "Sygnal", config: Dict[str, Any]):
+    async def create(
+        cls, name: str, sygnal: "Sygnal", config: Dict[str, Any]
+    ) -> "Pushkin":
         """
         Override this if your pushkin needs to call async code in order to
         be constructed. Otherwise, it defaults to just invoking the Python-standard

--- a/sygnal/sygnal.py
+++ b/sygnal/sygnal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2025 New Vector Ltd.
 # Copyright 2019, 2020 The Matrix.org Foundation C.I.C.
 # Copyright 2018, 2019 New Vector Ltd.
@@ -16,7 +15,7 @@ import logging
 import logging.config
 import os
 import sys
-from typing import Any, Dict, Set, Type
+from typing import Any
 
 import opentracing
 import prometheus_client
@@ -30,7 +29,7 @@ from sygnal.notifications import Pushkin
 
 logger = logging.getLogger(__name__)
 
-CONFIG_DEFAULTS: Dict[str, Any] = {
+CONFIG_DEFAULTS: dict[str, Any] = {
     "http": {"port": 5000, "bind_addresses": ["127.0.0.1"]},
     "log": {"setup": {}, "access": {"x_forwarded_for": False}},
     "metrics": {
@@ -51,7 +50,7 @@ CONFIG_DEFAULTS: Dict[str, Any] = {
 class Sygnal:
     def __init__(
         self,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         tracer: Tracer = opentracing.tracer,
     ):
         """
@@ -61,7 +60,7 @@ class Sygnal:
             tracer (optional): an OpenTracing tracer. The default is the no-op tracer.
         """
         self.config = config
-        self.pushkins: Dict[str, Pushkin] = {}
+        self.pushkins: dict[str, Pushkin] = {}
         self.tracer = tracer
 
         logging_dict_config = config["log"]["setup"]
@@ -137,7 +136,7 @@ class Sygnal:
                     "Unknown OpenTracing implementation: %s.", tracecfg["impl"]
                 )
 
-    async def _make_pushkin(self, app_name: str, app_config: Dict[str, Any]) -> Pushkin:
+    async def _make_pushkin(self, app_name: str, app_config: dict[str, Any]) -> Pushkin:
         """
         Load and instantiate a pushkin.
         Args:
@@ -159,7 +158,7 @@ class Sygnal:
         logger.info("Importing pushkin module: %s", to_import)
         pushkin_module = importlib.import_module(to_import)
         logger.info("Creating pushkin: %s", to_construct)
-        clarse: Type[Pushkin] = getattr(pushkin_module, to_construct)
+        clarse: type[Pushkin] = getattr(pushkin_module, to_construct)
         return await clarse.create(app_name, self, app_config)
 
     async def _start(self) -> None:
@@ -169,7 +168,8 @@ class Sygnal:
                 self.pushkins[app_id] = await self._make_pushkin(app_id, app_cfg)
             except Exception:
                 logger.error(
-                    "Failed to load and create pushkin for kind '%s'" % app_cfg["type"]
+                    "Failed to load and create pushkin for kind '%s'",
+                    app_cfg["type"],
                 )
                 raise
 
@@ -208,17 +208,17 @@ class Sygnal:
         asyncio.run(self._start())
 
 
-def parse_config() -> Dict[str, Any]:
+def parse_config() -> dict[str, Any]:
     """
     Find and load Sygnal's configuration file.
     Returns:
         A loaded configuration.
     """
     config_path = os.getenv("SYGNAL_CONF", "sygnal.yaml")
-    print("Using configuration file: %s" % config_path, file=sys.stderr)
+    print(f"Using configuration file: {config_path}", file=sys.stderr)
     try:
         with open(config_path) as file_handle:
-            config: Dict[str, Any] = yaml.safe_load(file_handle)
+            config: dict[str, Any] = yaml.safe_load(file_handle)
             return config
     except FileNotFoundError:
         logger.critical(
@@ -229,7 +229,7 @@ def parse_config() -> Dict[str, Any]:
         raise
 
 
-def check_config(config: Dict[str, Any]) -> None:
+def check_config(config: dict[str, Any]) -> None:
     """
     Lightly check the configuration and issue warnings as appropriate.
     Args:
@@ -238,13 +238,13 @@ def check_config(config: Dict[str, Any]) -> None:
     UNDERSTOOD_CONFIG_FIELDS = CONFIG_DEFAULTS.keys()
 
     def check_section(
-        section_name: str, known_keys: Set[str], cfgpart: Dict[str, Any] = config
+        section_name: str, known_keys: set[str], cfgpart: dict[str, Any] = config
     ) -> None:
         nonunderstood = set(cfgpart[section_name].keys()).difference(known_keys)
         if len(nonunderstood) > 0:
             logger.warning(
-                f"The following configuration fields in '{section_name}' "
-                f"are not understood: %s",
+                "The following configuration fields in '%s' are not understood: %s",
+                section_name,
                 nonunderstood,
             )
 
@@ -272,8 +272,8 @@ def check_config(config: Dict[str, Any]) -> None:
 
 
 def merge_left_with_defaults(
-    defaults: Dict[str, Any], loaded_config: Dict[str, Any]
-) -> Dict[str, Any]:
+    defaults: dict[str, Any], loaded_config: dict[str, Any]
+) -> dict[str, Any]:
     """
     Merge two configurations, with one of them overriding the other.
     Args:

--- a/sygnal/sygnal.py
+++ b/sygnal/sygnal.py
@@ -16,7 +16,7 @@ import logging
 import logging.config
 import os
 import sys
-from typing import Any, Dict, Set
+from typing import Any, Dict, Set, Type
 
 import opentracing
 import prometheus_client
@@ -159,7 +159,7 @@ class Sygnal:
         logger.info("Importing pushkin module: %s", to_import)
         pushkin_module = importlib.import_module(to_import)
         logger.info("Creating pushkin: %s", to_construct)
-        clarse = getattr(pushkin_module, to_construct)
+        clarse: Type[Pushkin] = getattr(pushkin_module, to_construct)
         return await clarse.create(app_name, self, app_config)
 
     async def _start(self) -> None:
@@ -218,7 +218,8 @@ def parse_config() -> Dict[str, Any]:
     print("Using configuration file: %s" % config_path, file=sys.stderr)
     try:
         with open(config_path) as file_handle:
-            return yaml.safe_load(file_handle)
+            config: Dict[str, Any] = yaml.safe_load(file_handle)
+            return config
     except FileNotFoundError:
         logger.critical(
             "Could not find configuration file!\nPath: %s\nAbsolute Path: %s",

--- a/sygnal/utils.py
+++ b/sygnal/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2025 New Vector Ltd.
 # Copyright 2019 The Matrix.org Foundation C.I.C.
 #
@@ -8,14 +7,15 @@
 # Originally licensed under the Apache License, Version 2.0:
 # <http://www.apache.org/licenses/LICENSE-2.0>.
 import json
+from collections.abc import MutableMapping
 from logging import LoggerAdapter
-from typing import Any, MutableMapping, Tuple
+from typing import Any
 
 
 class NotificationLoggerAdapter(LoggerAdapter):
     def process(
         self, msg: str, kwargs: MutableMapping[str, Any]
-    ) -> Tuple[str, MutableMapping[str, Any]]:
+    ) -> tuple[str, MutableMapping[str, Any]]:
         assert self.extra
         return f"[{self.extra['request_id']}] {msg}", kwargs
 

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -124,7 +124,7 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
     ) -> List[str]:
         p256dh = device.pushkey
         if not isinstance(device.data, dict):
-            logger.warn(
+            logger.warning(
                 "Rejecting pushkey %s; device.data is not a dict", device.pushkey
             )
             return [device.pushkey]
@@ -138,7 +138,7 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
         auth = device.data.get("auth")
 
         if not p256dh or not isinstance(endpoint, str) or not isinstance(auth, str):
-            logger.warn(
+            logger.warning(
                 "Rejecting pushkey; subscription info incomplete or invalid "
                 + "(p256dh: %s, endpoint: %r, auth: %r)",
                 p256dh,
@@ -298,7 +298,7 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
                 pass
         # permanent errors
         if response.status == 404 or response.status == 410:
-            logger.warn(
+            logger.warning(
                 "Rejecting pushkey %s; subscription is invalid on %s: %d: %s",
                 pushkey,
                 endpoint_domain,
@@ -308,7 +308,7 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
             return True
         # and temporary ones
         if response.status >= 400:
-            logger.warn(
+            logger.warning(
                 "webpush request failed for pushkey %s; %s responded with %d: %s",
                 pushkey,
                 endpoint_domain,

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2025 New Vector Ltd.
 # Copyright 2021 The Matrix.org Foundation C.I.C.
 #
@@ -13,7 +12,7 @@ import logging
 import os.path
 from base64 import urlsafe_b64encode
 from hashlib import blake2s
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Pattern
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 import aiohttp
@@ -31,6 +30,8 @@ from sygnal.notifications import (
 )
 
 if TYPE_CHECKING:
+    from re import Pattern
+
     from sygnal.sygnal import Sygnal
 
 QUEUE_TIME_HISTOGRAM = Histogram(
@@ -74,7 +75,7 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
         "ttl",
     } | ConcurrencyLimitedPushkin.UNDERSTOOD_CONFIG_FIELDS
 
-    def __init__(self, name: str, sygnal: "Sygnal", config: Dict[str, Any]):
+    def __init__(self, name: str, sygnal: "Sygnal", config: dict[str, Any]):
         super().__init__(name, sygnal, config)
 
         nonunderstood = self.cfg.keys() - self.UNDERSTOOD_CONFIG_FIELDS
@@ -97,7 +98,7 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
         )
         self.http_request_factory = HttpRequestFactory()
 
-        self.allowed_endpoints: Optional[List[Pattern[str]]] = None
+        self.allowed_endpoints: list[Pattern[str]] | None = None
         allowed_endpoints = self.get_config("allowed_endpoints", list)
         if allowed_endpoints:
             self.allowed_endpoints = list(map(glob_to_regex, allowed_endpoints))
@@ -121,7 +122,7 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
 
     async def _dispatch_notification_unlimited(
         self, n: Notification, device: Device, context: NotificationContext
-    ) -> List[str]:
+    ) -> list[str]:
         p256dh = device.pushkey
         if not isinstance(device.data, dict):
             logger.warning(
@@ -140,7 +141,7 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
         if not p256dh or not isinstance(endpoint, str) or not isinstance(auth, str):
             logger.warning(
                 "Rejecting pushkey; subscription info incomplete or invalid "
-                + "(p256dh: %s, endpoint: %r, auth: %r)",
+                "(p256dh: %s, endpoint: %r, auth: %r)",
                 p256dh,
                 endpoint,
                 auth,
@@ -180,28 +181,26 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
 
         # note that webpush modifies vapid_claims, so make sure it's only used once
         vapid_claims = {
-            "sub": "mailto:{}".format(self.vapid_contact_email),
+            "sub": f"mailto:{self.vapid_contact_email}",
         }
         # we use the semaphore to actually limit the number of concurrent
         # requests, since the connection pool alone does not perform limiting.
-        with QUEUE_TIME_HISTOGRAM.time():
-            with PENDING_REQUESTS_GAUGE.track_inprogress():
-                await self.connection_semaphore.acquire()
+        with QUEUE_TIME_HISTOGRAM.time(), PENDING_REQUESTS_GAUGE.track_inprogress():
+            await self.connection_semaphore.acquire()
         try:
-            with SEND_TIME_HISTOGRAM.time():
-                with ACTIVE_REQUESTS_GAUGE.track_inprogress():
-                    request = webpush(
-                        subscription_info=subscription_info,
-                        data=data,
-                        ttl=self.ttl,
-                        vapid_private_key=self.vapid_private_key,
-                        vapid_claims=vapid_claims,
-                        requests_session=self.http_request_factory,
-                    )
-                    response = await request.execute(
-                        self.http_session, low_priority, topic, self.proxy_url
-                    )
-                    response_text = await response.text()
+            with SEND_TIME_HISTOGRAM.time(), ACTIVE_REQUESTS_GAUGE.track_inprogress():
+                request = webpush(
+                    subscription_info=subscription_info,
+                    data=data,
+                    ttl=self.ttl,
+                    vapid_private_key=self.vapid_private_key,
+                    vapid_claims=vapid_claims,
+                    requests_session=self.http_request_factory,
+                )
+                response = await request.execute(
+                    self.http_session, low_priority, topic, self.proxy_url
+                )
+                response_text = await response.text()
         finally:
             self.connection_semaphore.release()
 
@@ -213,7 +212,7 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
         return []
 
     @staticmethod
-    def _build_payload(n: Notification, device: Device) -> Dict[str, Any]:
+    def _build_payload(n: Notification, device: Device) -> dict[str, Any]:
         """
         Build the payload data to be sent.
 
@@ -318,7 +317,7 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
         elif response.status != 201:
             logger.info(
                 "webpush request for pushkey %s didn't respond with 201; "
-                + "%s responded with %d: %s",
+                "%s responded with %d: %s",
                 pushkey,
                 endpoint_domain,
                 response.status,
@@ -377,7 +376,7 @@ class HttpDelayedRequest:
     """
 
     status_code: int = 200
-    text: Optional[str] = None
+    text: str | None = None
 
     def __init__(self, endpoint: str, data: bytes, vapid_headers: CaseInsensitiveDict):
         self.endpoint = endpoint
@@ -388,8 +387,8 @@ class HttpDelayedRequest:
         self,
         http_session: aiohttp.ClientSession,
         low_priority: bool,
-        topic: Optional[bytes],
-        proxy_url: Optional[str] = None,
+        topic: bytes | None,
+        proxy_url: str | None = None,
     ) -> aiohttp.ClientResponse:
         headers = {
             "User-Agent": "sygnal",

--- a/sygnal/webpushpushkin.py
+++ b/sygnal/webpushpushkin.py
@@ -282,7 +282,7 @@ class WebpushPushkin(ConcurrencyLimitedPushkin):
         Returns:
             Boolean whether the puskey should be rejected
         """
-        ttl_response_headers: List[str] = response.headers.getall("TTL", [])
+        ttl_response_headers: list[str] = response.headers.getall("TTL", [])
         if ttl_response_headers:
             try:
                 ttl_given = int(ttl_response_headers[0])

--- a/tests/test_apns.py
+++ b/tests/test_apns.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2025 New Vector Ltd.
 # Copyright 2019 The Matrix.org Foundation C.I.C.
 #
@@ -7,7 +6,7 @@
 #
 # Originally licensed under the Apache License, Version 2.0:
 # <http://www.apache.org/licenses/LICENSE-2.0>.
-from typing import Any, Dict
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from aioapns.common import NotificationResult, PushType
@@ -63,7 +62,7 @@ class ApnsTestCase(testutils.TestCase):
         assert isinstance(test_pushkin, ApnsPushkin)
         return test_pushkin
 
-    def config_setup(self, config: Dict[str, Any]) -> None:
+    def config_setup(self, config: dict[str, Any]) -> None:
         super().config_setup(config)
         config["apps"][PUSHKIN_ID] = {"type": "apns", "certfile": TEST_CERTFILE_PATH}
         config["apps"][PUSHKIN_ID_WITHOUT_BADGES] = {

--- a/tests/test_apns.py
+++ b/tests/test_apns.py
@@ -95,8 +95,8 @@ class ApnsTestCase(testutils.TestCase):
         test_pushkin_push_type = self.get_test_pushkin(PUSHKIN_ID_WITH_PUSH_TYPE)
         # type safety: using ignore here due to mypy not handling monkeypatching,
         # see https://github.com/python/mypy/issues/2427
-        test_pushkin._send_notification = self.apns_pushkin_snotif  # type: ignore[assignment] # noqa: E501
-        test_pushkin_push_type._send_notification = self.apns_pushkin_snotif  # type: ignore[assignment] # noqa: E501
+        test_pushkin._send_notification = self.apns_pushkin_snotif  # type: ignore[method-assign]
+        test_pushkin_push_type._send_notification = self.apns_pushkin_snotif  # type: ignore[method-assign]
 
     async def test_payload_truncation(self) -> None:
         """
@@ -318,7 +318,7 @@ class ApnsTestCase(testutils.TestCase):
             NotificationResult("notID", "200")
         )
         test_pushkin = self.get_test_pushkin(PUSHKIN_ID_WITHOUT_BADGES)
-        test_pushkin._send_notification = self.apns_pushkin_snotif  # type: ignore[assignment] # noqa: E501
+        test_pushkin._send_notification = self.apns_pushkin_snotif  # type: ignore[method-assign]
 
         # Act
         resp = await self._request(
@@ -347,7 +347,7 @@ class ApnsTestCase(testutils.TestCase):
             NotificationResult("notID", "200")
         )
         test_pushkin = self.get_test_pushkin(PUSHKIN_ID_WITHOUT_BADGES)
-        test_pushkin._send_notification = self.apns_pushkin_snotif  # type: ignore[assignment] # noqa: E501
+        test_pushkin._send_notification = self.apns_pushkin_snotif  # type: ignore[method-assign]
 
         # Act
         resp = await self._request(

--- a/tests/test_apnstruncate.py
+++ b/tests/test_apnstruncate.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2025 New Vector Ltd.
 # Copyright 2015 OpenMarket Ltd.
 #
@@ -14,7 +13,7 @@
 
 import string
 import unittest
-from typing import Any, Dict
+from typing import Any
 
 from sygnal.apnstruncate import json_encode, truncate
 
@@ -51,7 +50,7 @@ def sillystring(length: int, offset: int = 0) -> str:
     return "".join([chars[(i + offset) % len(chars)] for i in range(length)])
 
 
-def payload_for_aps(aps: Dict[str, Any]) -> Dict[str, Any]:
+def payload_for_aps(aps: dict[str, Any]) -> dict[str, Any]:
     """
     Returns the APNS payload for an 'aps' dictionary.
     """

--- a/tests/test_concurrency_limit.py
+++ b/tests/test_concurrency_limit.py
@@ -8,7 +8,7 @@
 # <http://www.apache.org/licenses/LICENSE-2.0>.
 
 import asyncio
-from typing import Any, Dict, List
+from typing import Any
 
 from sygnal.notifications import (
     ConcurrencyLimitedPushkin,
@@ -39,7 +39,7 @@ DEVICE_APNS_EXAMPLE = {
 class SlowConcurrencyLimitedDummyPushkin(ConcurrencyLimitedPushkin):
     async def _dispatch_notification_unlimited(
         self, n: Notification, device: Device, context: NotificationContext
-    ) -> List[str]:
+    ) -> list[str]:
         """
         We will deliver the notification to the mighty nobody
         and we will take one second to do it, because we are slow!
@@ -49,7 +49,7 @@ class SlowConcurrencyLimitedDummyPushkin(ConcurrencyLimitedPushkin):
 
 
 class ConcurrencyLimitTestCase(TestCase):
-    def config_setup(self, config: Dict[str, Any]) -> None:
+    def config_setup(self, config: dict[str, Any]) -> None:
         super().config_setup(config)
         config["apps"]["com.example.gcm"] = {
             "type": "tests.test_concurrency_limit.SlowConcurrencyLimitedDummyPushkin",

--- a/tests/test_gcm.py
+++ b/tests/test_gcm.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2025 New Vector Ltd.
 # Copyright 2019 The Matrix.org Foundation C.I.C.
 #
@@ -8,7 +7,7 @@
 # Originally licensed under the Apache License, Version 2.0:
 # <http://www.apache.org/licenses/LICENSE-2.0>.
 import json
-from typing import TYPE_CHECKING, Any, Dict, Tuple
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
 from sygnal.exceptions import TemporaryNotificationDispatchException
@@ -84,7 +83,7 @@ class StubCredentials:
         if self.valid:
             return "myaccesstoken"
         else:
-            raise Exception()
+            raise Exception
 
     async def refresh(self, request: Any) -> None:
         self.valid = True
@@ -96,18 +95,18 @@ class StubGcmPushkin(GcmPushkin):
     can be preloaded with virtual requests.
     """
 
-    def __init__(self, name: str, sygnal: "Sygnal", config: Dict[str, Any]):
+    def __init__(self, name: str, sygnal: "Sygnal", config: dict[str, Any]):
         super().__init__(name, sygnal, config)
         self.preloaded_response = DummyResponse(0)
-        self.preloaded_response_payload: Dict[str, Any] = {}
-        self.last_request_body: Dict[str, Any] = {}
-        self.last_request_headers: Dict[str, str] = {}
+        self.preloaded_response_payload: dict[str, Any] = {}
+        self.last_request_body: dict[str, Any] = {}
+        self.last_request_headers: dict[str, str] = {}
         self.num_requests = 0
         if self.api_version is APIVersion.V1:
             self.credentials = StubCredentials()  # type: ignore[assignment]
 
     def preload_with_response(
-        self, code: int, response_payload: Dict[str, Any]
+        self, code: int, response_payload: dict[str, Any]
     ) -> None:
         """
         Preloads a fake GCM response.
@@ -116,8 +115,8 @@ class StubGcmPushkin(GcmPushkin):
         self.preloaded_response_payload = response_payload
 
     async def _perform_http_request(  # type: ignore[override]
-        self, body: Dict[str, Any], headers: Dict[str, str]
-    ) -> Tuple[DummyResponse, str]:
+        self, body: dict[str, Any], headers: dict[str, str]
+    ) -> tuple[DummyResponse, str]:
         self.last_request_body = body
         self.last_request_headers = headers
         self.num_requests += 1
@@ -147,7 +146,7 @@ FAKE_SERVICE_ACCOUNT_FILE = b"""
 
 
 class GcmTestCase(testutils.TestCase):
-    def config_setup(self, config: Dict[str, Any]) -> None:
+    def config_setup(self, config: dict[str, Any]) -> None:
         config["apps"]["com.example.gcm"] = {
             "type": "tests.test_gcm.StubGcmPushkin",
             "api_key": "kii",

--- a/tests/test_gcm.py
+++ b/tests/test_gcm.py
@@ -236,7 +236,7 @@ class GcmTestCase(testutils.TestCase):
 
         # type safety: using ignore here due to mypy not handling monkeypatching,
         # see https://github.com/python/mypy/issues/2427
-        gcm._request_dispatch = self.apns_pushkin_snotif  # type: ignore[assignment] # noqa: E501
+        gcm._request_dispatch = self.apns_pushkin_snotif  # type: ignore[method-assign]
 
         method = self.apns_pushkin_snotif
         method.side_effect = testutils.make_async_magic_mock(([], []))
@@ -280,7 +280,7 @@ class GcmTestCase(testutils.TestCase):
 
         # type safety: using ignore here due to mypy not handling monkeypatching,
         # see https://github.com/python/mypy/issues/2427
-        gcm._request_dispatch = self.apns_pushkin_snotif  # type: ignore[assignment] # noqa: E501
+        gcm._request_dispatch = self.apns_pushkin_snotif  # type: ignore[method-assign]
 
         method = self.apns_pushkin_snotif
         method.side_effect = testutils.make_async_magic_mock(([], []))
@@ -494,7 +494,7 @@ class GcmTestCase(testutils.TestCase):
 
         # type safety: using ignore here due to mypy not handling monkeypatching,
         # see https://github.com/python/mypy/issues/2427
-        gcm._request_dispatch = self.gcm_pushkin_snotif  # type: ignore[assignment] # noqa: E501
+        gcm._request_dispatch = self.gcm_pushkin_snotif  # type: ignore[method-assign]
 
         async def side_effect(*_args: Any, **_kwargs: Any) -> None:
             raise TemporaryNotificationDispatchException(
@@ -775,7 +775,7 @@ class GcmTestCase(testutils.TestCase):
 
         # type safety: using ignore here due to mypy not handling monkeypatching,
         # see https://github.com/python/mypy/issues/2427
-        gcm._request_dispatch = self.apns_pushkin_snotif  # type: ignore[assignment] # noqa: E501
+        gcm._request_dispatch = self.apns_pushkin_snotif  # type: ignore[method-assign]
 
         method = self.apns_pushkin_snotif
         method.side_effect = testutils.make_async_magic_mock(([], []))

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -6,7 +6,7 @@
 #
 # Originally licensed under the Apache License, Version 2.0:
 # <http://www.apache.org/licenses/LICENSE-2.0>.
-from typing import Any, Dict
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from aioapns.common import NotificationResult
@@ -54,7 +54,7 @@ class HttpTestCase(testutils.TestCase):
         # Since no certificate exists, don't try to read it.
         patch("sygnal.apnspushkin.ApnsPushkin._report_certificate_expiration").start()
 
-    def config_setup(self, config: Dict[str, Any]) -> None:
+    def config_setup(self, config: dict[str, Any]) -> None:
         super().config_setup(config)
         config["apps"][PUSHKIN_ID_1] = {"type": "apns", "certfile": TEST_CERTFILE_PATH}
         config["apps"][PUSHKIN_ID_2] = {"type": "apns", "certfile": TEST_CERTFILE_PATH}
@@ -62,7 +62,7 @@ class HttpTestCase(testutils.TestCase):
 
     def _setup_apns_pushkin_snotif(self) -> MagicMock:
         self.apns_pushkin_snotif = MagicMock()
-        for key, value in self.sygnal.pushkins.items():
+        for value in self.sygnal.pushkins.values():
             assert isinstance(value, ApnsPushkin)
             # type safety: ignore is used here due to mypy not handling monkeypatching,
             # see https://github.com/python/mypy/issues/2427

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -66,7 +66,7 @@ class HttpTestCase(testutils.TestCase):
             assert isinstance(value, ApnsPushkin)
             # type safety: ignore is used here due to mypy not handling monkeypatching,
             # see https://github.com/python/mypy/issues/2427
-            value._send_notification = self.apns_pushkin_snotif  # type: ignore[assignment] # noqa: E501
+            value._send_notification = self.apns_pushkin_snotif  # type: ignore[method-assign]
         return self.apns_pushkin_snotif
 
     async def test_with_specific_appid(self) -> None:

--- a/tests/test_proxy_url_parsing.py
+++ b/tests/test_proxy_url_parsing.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2025 New Vector Ltd.
 # Copyright 2020 The Matrix.org Foundation C.I.C.
 #

--- a/tests/test_pushgateway_api_v1.py
+++ b/tests/test_pushgateway_api_v1.py
@@ -7,7 +7,7 @@
 # Originally licensed under the Apache License, Version 2.0:
 # <http://www.apache.org/licenses/LICENSE-2.0>.
 
-from typing import Any, Dict, List
+from typing import Any
 
 from sygnal.exceptions import (
     NotificationDispatchException,
@@ -55,7 +55,7 @@ class StubPushkin(Pushkin):
 
     async def dispatch_notification(
         self, n: Notification, device: Device, context: NotificationContext
-    ) -> List[str]:
+    ) -> list[str]:
         if device.pushkey == "raise_exception":
             raise Exception("Bad things have occurred!")
         elif device.pushkey == "remote_error":
@@ -70,7 +70,7 @@ class StubPushkin(Pushkin):
 
 
 class PushGatewayApiV1TestCase(testutils.TestCase):
-    def config_setup(self, config: Dict[str, Any]) -> None:
+    def config_setup(self, config: dict[str, Any]) -> None:
         """
         Set up a StubPushkin for the test.
         """

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2025 New Vector Ltd.
 # Copyright 2019, 2020 The Matrix.org Foundation C.I.C.
 #
@@ -10,14 +9,16 @@
 import json
 import pathlib
 from collections.abc import AsyncGenerator
-from typing import Any, Dict, List, Union
+from typing import TYPE_CHECKING, Any
 
-import aiohttp.test_utils
 import pytest_asyncio
 from multidict import CIMultiDict
 
 from sygnal.http import create_app
 from sygnal.sygnal import CONFIG_DEFAULTS, Sygnal, merge_left_with_defaults
+
+if TYPE_CHECKING:
+    import aiohttp.test_utils
 
 REQ_PATH = "/_matrix/push/v1/notify"
 
@@ -25,16 +26,14 @@ REQ_PATH = "/_matrix/push/v1/notify"
 class TestCase:
     """Base class for Sygnal integration tests using aiohttp test client."""
 
-    def config_setup(self, config: Dict[str, Any]) -> None:
+    def config_setup(self, config: dict[str, Any]) -> None:
         pass
 
     def pre_setup(self) -> None:
         """Hook called before Sygnal initialization. Override for mocking."""
-        pass
 
     def post_setup(self) -> None:
         """Hook called after Sygnal and pushkins are initialized."""
-        pass
 
     @pytest_asyncio.fixture(autouse=True)
     async def _setup_sygnal(
@@ -71,7 +70,7 @@ class TestCase:
 
         self.tmp_path = tmp_path
 
-        config: Dict[str, Any] = {"apps": {}, "log": logging_config}
+        config: dict[str, Any] = {"apps": {}, "log": logging_config}
         self.config_setup(config)
 
         config = merge_left_with_defaults(CONFIG_DEFAULTS, config)
@@ -97,7 +96,7 @@ class TestCase:
 
         patch.stopall()
 
-    def _make_dummy_notification(self, devices: List[Dict[str, Any]]) -> Dict[str, Any]:
+    def _make_dummy_notification(self, devices: list[dict[str, Any]]) -> dict[str, Any]:
         return {
             "notification": {
                 "id": "$3957tyerfgewrf384",
@@ -120,8 +119,8 @@ class TestCase:
         }
 
     def _make_dummy_notification_event_id_only(
-        self, devices: List[Dict[str, Any]]
-    ) -> Dict[str, Any]:
+        self, devices: list[dict[str, Any]]
+    ) -> dict[str, Any]:
         return {
             "notification": {
                 "room_id": "!slw48wfj34rtnrf:example.com",
@@ -132,8 +131,8 @@ class TestCase:
         }
 
     def _make_dummy_notification_badge_only(
-        self, devices: List[Dict[str, Any]]
-    ) -> Dict[str, Any]:
+        self, devices: list[dict[str, Any]]
+    ) -> dict[str, Any]:
         return {
             "notification": {
                 "id": "",
@@ -149,8 +148,8 @@ class TestCase:
     # character. The truncation logic should recognize this and return the string starting before
     # the `⚑`, with a `…` appended to indicate the string was truncated.
     def _make_dummy_notification_large_fields(
-        self, devices: List[Dict[str, Any]]
-    ) -> Dict[str, Any]:
+        self, devices: list[dict[str, Any]]
+    ) -> dict[str, Any]:
         return {
             "notification": {
                 "id": "$3957tyerfgewrf384",
@@ -236,7 +235,7 @@ ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo",
             }
         }
 
-    async def _request(self, payload: Union[str, dict]) -> Union[dict, int]:
+    async def _request(self, payload: str | dict) -> dict | int:
         """
         Make a dummy request to the notify endpoint with the specified payload
 
@@ -262,9 +261,7 @@ ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo",
 
         return await resp.json()  # type: ignore[no-any-return]
 
-    async def _multi_requests(
-        self, payloads: List[Union[str, dict]]
-    ) -> List[Union[dict, int]]:
+    async def _multi_requests(self, payloads: list[str | dict]) -> list[dict | int]:
         """
         Make multiple dummy requests to the notify endpoint with the specified payloads.
         """

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -12,6 +12,7 @@ import pathlib
 from collections.abc import AsyncGenerator
 from typing import Any, Dict, List, Union
 
+import aiohttp.test_utils
 import pytest_asyncio
 from multidict import CIMultiDict
 
@@ -88,7 +89,7 @@ class TestCase:
         self.post_setup()
 
         app = create_app(self.sygnal)
-        self.client = await aiohttp_client(app)
+        self.client: aiohttp.test_utils.TestClient = await aiohttp_client(app)
 
         yield
 
@@ -259,7 +260,7 @@ ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo",
         if resp.status != 200:
             return resp.status
 
-        return await resp.json()
+        return await resp.json()  # type: ignore[no-any-return]
 
     async def _multi_requests(
         self, payloads: List[Union[str, dict]]

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -8,6 +8,8 @@
 # Originally licensed under the Apache License, Version 2.0:
 # <http://www.apache.org/licenses/LICENSE-2.0>.
 import json
+import pathlib
+from collections.abc import AsyncGenerator
 from typing import Any, Dict, List, Union
 
 import pytest_asyncio
@@ -34,7 +36,9 @@ class TestCase:
         pass
 
     @pytest_asyncio.fixture(autouse=True)
-    async def _setup_sygnal(self, aiohttp_client, tmp_path):
+    async def _setup_sygnal(
+        self, aiohttp_client: Any, tmp_path: pathlib.Path
+    ) -> AsyncGenerator[None]:
         logging_config = {
             "setup": {
                 "disable_existing_loggers": False,
@@ -92,7 +96,7 @@ class TestCase:
 
         patch.stopall()
 
-    def _make_dummy_notification(self, devices):
+    def _make_dummy_notification(self, devices: List[Dict[str, Any]]) -> Dict[str, Any]:
         return {
             "notification": {
                 "id": "$3957tyerfgewrf384",
@@ -114,7 +118,9 @@ class TestCase:
             }
         }
 
-    def _make_dummy_notification_event_id_only(self, devices):
+    def _make_dummy_notification_event_id_only(
+        self, devices: List[Dict[str, Any]]
+    ) -> Dict[str, Any]:
         return {
             "notification": {
                 "room_id": "!slw48wfj34rtnrf:example.com",
@@ -124,7 +130,9 @@ class TestCase:
             }
         }
 
-    def _make_dummy_notification_badge_only(self, devices):
+    def _make_dummy_notification_badge_only(
+        self, devices: List[Dict[str, Any]]
+    ) -> Dict[str, Any]:
         return {
             "notification": {
                 "id": "",
@@ -139,7 +147,9 @@ class TestCase:
     # This will make the truncation (which is `str[: 1024 - 3]`) occur in the middle of a unicode
     # character. The truncation logic should recognize this and return the string starting before
     # the `⚑`, with a `…` appended to indicate the string was truncated.
-    def _make_dummy_notification_large_fields(self, devices):
+    def _make_dummy_notification_large_fields(
+        self, devices: List[Dict[str, Any]]
+    ) -> Dict[str, Any]:
         return {
             "notification": {
                 "id": "$3957tyerfgewrf384",
@@ -264,13 +274,13 @@ ooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxooooooooooxxxxxxxxxxoooooooooo",
 
 
 class DummyResponse:
-    def __init__(self, code):
+    def __init__(self, code: int) -> None:
         self.status = code
         self.headers: CIMultiDict[str] = CIMultiDict()
 
 
-def make_async_magic_mock(ret_val):
-    async def dummy(*_args, **_kwargs):
+def make_async_magic_mock(ret_val: Any) -> Any:
+    async def dummy(*_args: Any, **_kwargs: Any) -> Any:
         return ret_val
 
     return dummy


### PR DESCRIPTION
## Summary

- Replace deprecated `logger.warn()` with `logger.warning()`
- Add missing type annotations and tighten mypy config (`disallow_untyped_defs` now passes on all modules)
- Narrow `type: ignore` comments to specific error codes and enable `warn_unused_ignores`
- Enable `warn_return_any` in mypy and fix all violations
- Enable ruff rules: UP (pyupgrade), B (bugbear), C4, SIM, RUF, PIE, RSE, G, PERF, TC
- Drop explicit `target-version` from ruff config (inferred from `requires-python`)
- Modernize type annotations to Python 3.10+ syntax (`dict` not `Dict`, `X | Y` not `Union`)
- Add `from err` to raise-in-except blocks, merge nested `with` statements, annotate `ClassVar`
- Remove dead `ProxyConnectError` exception class (unused after Twisted removal)
- Remove `# -*- coding: utf-8 -*-` declarations (unnecessary since Python 3)

## Notes

- `_choppable_get` in `apnstruncate.py` now raises `ValueError` instead of implicitly returning `None` for unknown choppable types. The branches are exhaustive so this is unreachable in practice.
- `warn_return_any = False` for `sygnal.apnstruncate` module — needed due to `dict[str, Any]` access patterns.
- `PERF203` (try-except in loop) is suppressed — the loops have intentional error handling.

## Test plan

- [x] `uv run mypy sygnal/ tests/` passes with zero errors
- [x] `uv run ruff check sygnal/ tests/` passes
- [x] `uv run pytest tests/` — 55 tests pass
- [x] CI green

> Part 6 of 7 in the repository modernisation series. Builds on #456.