### PR TITLE
Exclude dependabot from changelog check

### DIFF
--- a/.github/workflows/changelog_check.yml
+++ b/.github/workflows/changelog_check.yml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   check-newsfile:
-    if: ${{ github.base_ref == 'main'  || contains(github.base_ref, 'release-') }}
+    if: ${{ (github.base_ref == 'main'  || contains(github.base_ref, 'release-')) && github.event.pull_request.user.login != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/changelog.d/458.misc
+++ b/changelog.d/458.misc
@@ -1,0 +1,1 @@
+Exclude @dependabot from the changelog check GitHub Actions CI.


### PR DESCRIPTION
Otherwise we'll get CI failures on dependabot PRs for lack of changelog entry.