### PR TITLE
Harden the GitHub Actions workflows

### DIFF
--- a/.ci/scripts/triage_labelled_issue.sh
+++ b/.ci/scripts/triage_labelled_issue.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 1) Resolve project ID.
+PROJECT_ID=$(gh project view "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json | jq -r '.id')
+
+# 2) Find existing item (project card) for this issue.
+ITEM_ID=$(
+  gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json \
+  | jq -r --arg url "$ISSUE_URL" '.items[] | select(.content.url==$url) | .id' | head -n1
+)
+
+# 3) If one doesn't exist, add this issue to the project.
+if [ -z "${ITEM_ID:-}" ]; then
+  ITEM_ID=$(gh project item-add "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --url "$ISSUE_URL" --format json | jq -r '.id')
+fi
+
+# 4) Get Status field id + the option id for TARGET_STATUS.
+FIELDS_JSON=$(gh project field-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json)
+STATUS_FIELD=$(echo "$FIELDS_JSON" | jq -r '.fields[] | select(.name=="Status")')
+STATUS_FIELD_ID=$(echo "$STATUS_FIELD" | jq -r '.id')
+OPTION_ID=$(echo "$STATUS_FIELD" | jq -r --arg name "$TARGET_STATUS" '.options[] | select(.name==$name) | .id')
+
+if [ -z "${OPTION_ID:-}" ]; then
+  echo "No Status option named \"$TARGET_STATUS\" found"; exit 1
+fi
+
+# 5) Set Status (moves item to the matching column in the board view).
+gh project item-edit --id "$ITEM_ID" --project-id "$PROJECT_ID" --field-id "$STATUS_FIELD_ID" --single-select-option-id "$OPTION_ID"

--- a/.ci/scripts/triage_labelled_issue.sh
+++ b/.ci/scripts/triage_labelled_issue.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+#
+# Script taken from the Synapse repo:
+# https://github.com/element-hq/synapse/blob/2aef6c33a842fe7f50e0a8492a0396412aed5115/.ci/scripts/triage_labelled_issue.sh
 set -euo pipefail
 
 # 1) Resolve project ID.

--- a/.github/workflows/changelog_check.yml
+++ b/.github/workflows/changelog_check.yml
@@ -6,11 +6,12 @@ jobs:
     if: ${{ (github.base_ref == 'main'  || contains(github.base_ref, 'release-')) && github.event.pull_request.user.login != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           ref: ${{github.event.pull_request.head.sha}}
-      - uses: actions/setup-python@v6
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.11"
       - run: python -m pip install towncrier

--- a/.github/workflows/changelog_check.yml
+++ b/.github/workflows/changelog_check.yml
@@ -1,6 +1,10 @@
 name: Changelog
 on: [pull_request]
 
+permissions:
+  # Required to checkout the codebase.
+  contents: read
+
 jobs:
   check-newsfile:
     if: ${{ (github.base_ref == 'main'  || contains(github.base_ref, 'release-')) && github.event.pull_request.user.login != 'dependabot[bot]' }}

--- a/.github/workflows/docker_check.yml
+++ b/.github/workflows/docker_check.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
         with:
           platforms: arm64
 
@@ -43,7 +43,7 @@ jobs:
       # otherwise we can't export the multi-arch image later
       # https://github.com/docker/buildx/issues/59#issuecomment-2770311050
       - name: Set up Docker
-        uses: docker/setup-docker-action@v5.1.0
+        uses: docker/setup-docker-action@b2189fbf2a6592b51fee7cdd93ee2bfaeba733db # v5.1.0
         with:
           daemon-config: |
             {
@@ -54,7 +54,7 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Inspect builder
         run: docker buildx inspect
@@ -64,10 +64,12 @@ jobs:
       # (part of build system config in pyproject.toml) can deduce the package version.
       # See: https://github.com/marketplace/actions/build-and-push-docker-images#path-context
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Build all platforms
-        uses: docker/build-push-action@v7.1.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           push: false
@@ -86,7 +88,7 @@ jobs:
 
       # https://docs.docker.com/build/ci/github-actions/share-image-jobs/
       - name: Upload container image for subsequent steps
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sygnal_image
           path: ${{ runner.temp }}/sygnal_image.tar
@@ -98,7 +100,7 @@ jobs:
     needs: build
     steps:
       - name: Download container image from build step
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: sygnal_image
           path: ${{ runner.temp }}
@@ -107,7 +109,9 @@ jobs:
         run: |
           docker image load --input ${{ runner.temp }}/sygnal_image.tar
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Prepare test setup
         run: |
@@ -153,7 +157,7 @@ jobs:
 
       - name: Upload mitmdump output
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: proxytest_mitmdump
           path: scripts-dev/proxy-test/out/mitmdump_out

--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -16,26 +16,26 @@ jobs:
     steps:
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
         with:
           platforms: arm64
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Inspect builder
         run: docker buildx inspect
 
       - name: Log in to DockerHub
-        uses: docker/login-action@v4.1.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Calculate docker image tags
         id: set-tag
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: matrixdotorg/sygnal
           tags: |
@@ -46,10 +46,12 @@ jobs:
       # (part of build system config in pyproject.toml) can deduce the package version.
       # See: https://github.com/marketplace/actions/build-and-push-docker-images#path-context
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Build and push all platforms
-        uses: docker/build-push-action@v7.1.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           push: true

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -4,6 +4,10 @@ on:
     branches: ["main"]
   pull_request:
 
+permissions:
+  # Required to checkout the codebase.
+  contents: read
+
 jobs:
   check-code-style:
     runs-on: ubuntu-latest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -8,10 +8,12 @@ jobs:
   check-code-style:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Poetry
-        uses: matrix-org/setup-python-poetry@v2
+        uses: matrix-org/setup-python-poetry@5bbf6603c5c930615ec8a29f1b5d7d258d905aa4 # v2
         with:
           install-project: "false"
           python-version: "3.12"
@@ -22,10 +24,12 @@ jobs:
   check-types-mypy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Poetry
-        uses: matrix-org/setup-python-poetry@v2
+        uses: matrix-org/setup-python-poetry@5bbf6603c5c930615ec8a29f1b5d7d258d905aa4 # v2
         with:
           install-project: "false"
           python-version: "3.12"
@@ -38,8 +42,10 @@ jobs:
     needs: [check-code-style, check-types-mypy]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
       - run: python -m pip install -e .
@@ -50,8 +56,10 @@ jobs:
     needs: [ check-code-style, check-types-mypy ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.10"
       - name: Patch pyproject.toml to require oldest dependencies

--- a/.github/workflows/triage_incoming.yml
+++ b/.github/workflows/triage_incoming.yml
@@ -5,6 +5,8 @@ on:
   issues:
     types: [ opened ]
 
+permissions: {}
+
 jobs:
   triage:
     uses: matrix-org/backend-meta/.github/workflows/triage-incoming.yml@18beaf3c8e536108bd04d18e6c3dc40ba3931e28 # v2.0.3

--- a/.github/workflows/triage_incoming.yml
+++ b/.github/workflows/triage_incoming.yml
@@ -1,3 +1,4 @@
+# This workflow is taken from the Synapse repo.
 name: Move new issues into the issue triage board
 
 on:
@@ -5,24 +6,10 @@ on:
     types: [ opened ]
 
 jobs:
-  add_new_issues:
-    name: Add new issues to the triage board
-    runs-on: ubuntu-latest
-    steps:
-      - uses: octokit/graphql-action@v2.x
-        id: add_to_project
-        with:
-          headers: '{"GraphQL-Features": "projects_next_graphql"}'
-          query: |
-              mutation add_to_project($projectid:ID!,$contentid:ID!) {
-                addProjectV2ItemById(input: {projectId: $projectid contentId: $contentid}) {
-                item {
-                  id
-                  }
-                }
-              }
-          projectid: ${{ env.PROJECT_ID }}
-          contentid: ${{ github.event.issue.node_id }}
-        env:
-          PROJECT_ID: "PVT_kwDOAIB0Bs4AFDdZ"
-          GITHUB_TOKEN: ${{ secrets.ELEMENT_BOT_TOKEN }}
+  triage:
+    uses: matrix-org/backend-meta/.github/workflows/triage-incoming.yml@18beaf3c8e536108bd04d18e6c3dc40ba3931e28 # v2.0.3
+    with:
+      project_id: 'PVT_kwDOAIB0Bs4AFDdZ'
+      content_id: ${{ github.event.issue.node_id }}
+    secrets:
+      github_access_token: ${{ secrets.ELEMENT_BOT_TOKEN }}

--- a/.github/workflows/triage_labelled.yml
+++ b/.github/workflows/triage_labelled.yml
@@ -1,4 +1,4 @@
-# This action is taken from the Synapse repo.
+# This workflow is taken from the Synapse repo.
 name: Move labelled issues to correct projects
 
 on:
@@ -29,6 +29,7 @@ jobs:
         with:
           # Only clone the script file we care about, instead of the whole repo.
           sparse-checkout: .ci/scripts/triage_labelled_issue.sh
+          persist-credentials: false
 
       - name: Ensure issue exists on the board, then set Status
         run: .ci/scripts/triage_labelled_issue.sh

--- a/.github/workflows/triage_labelled.yml
+++ b/.github/workflows/triage_labelled.yml
@@ -1,44 +1,34 @@
+# This action is taken from the Synapse repo.
 name: Move labelled issues to correct projects
 
 on:
   issues:
     types: [ labeled ]
 
+permissions: {}
+
 jobs:
   move_needs_info:
-    name: Move X-Needs-Info on the triage board
     runs-on: ubuntu-latest
     if: >
       contains(github.event.issue.labels.*.name, 'X-Needs-Info')
+    permissions:
+      contents: read
+    env:
+      # This token must have the following scopes: ["repo:public_repo", "admin:org->read:org", "user->read:user", "project"]
+      GITHUB_TOKEN: ${{ secrets.ELEMENT_BOT_TOKEN }}
+      PROJECT_OWNER: matrix-org
+      # Backend issue triage board.
+      # https://github.com/orgs/matrix-org/projects/67/views/1
+      PROJECT_NUMBER: 67
+      ISSUE_URL: ${{ github.event.issue.html_url }}
+      # This field is case-sensitive.
+      TARGET_STATUS: Needs info
     steps:
-      - uses: actions/add-to-project@main
-        id: add_project
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          project-url: "https://github.com/orgs/matrix-org/projects/67"
-          github-token: ${{ secrets.ELEMENT_BOT_TOKEN }}
-      - name: Set status
-        env:
-          GITHUB_TOKEN: ${{ secrets.ELEMENT_BOT_TOKEN }}
-        run: |
-          gh api graphql -f query='
-          mutation(
-              $project: ID!
-              $item: ID!
-              $fieldid: ID!
-              $columnid: String!
-            )  {
-            updateProjectV2ItemFieldValue(
-              input: {
-               projectId: $project
-                itemId: $item
-                fieldId: $fieldid
-                value: { 
-                  singleSelectOptionId: $columnid
-                  }
-              }
-            ) {
-              projectV2Item {
-                id
-              }
-            }
-          }' -f project="PVT_kwDOAIB0Bs4AFDdZ" -f item=${{ steps.add_project.outputs.itemId }} -f fieldid="PVTSSF_lADOAIB0Bs4AFDdZzgC6ZA4" -f columnid=ba22e43c --silent
+          # Only clone the script file we care about, instead of the whole repo.
+          sparse-checkout: .ci/scripts/triage_labelled_issue.sh
+
+      - name: Ensure issue exists on the board, then set Status
+        run: .ci/scripts/triage_labelled_issue.sh

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+# Taken from https://github.com/zizmorcore/zizmor-action/blob/64a6900ea7f40fab0caa7dcfc77b392d28fe0cb1/README.md
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6

--- a/changelog.d/467.misc
+++ b/changelog.d/467.misc
@@ -1,0 +1,1 @@
+Harden our GitHub Actions workflows using `zizmor`.


### PR DESCRIPTION
Hardens the GitHub Actions in this repo according to our [internal GHA hardening guidelines](https://docs.google.com/document/d/1nR8oCHyovy-YNrM9sJdEz3yj6EZdjdRNnsadVV_b6cY/edit?tab=t.0). Uses [`zizmor`](https://zizmor.sh/) as a "security linter", and for automatically checking workflows going forwards.

Recommended to review commit-by-commit.