### PR TITLE
Add `forward_event_type_for_event_id_only` option to the APNs and GCM/FCM pushkins

### DIFF
--- a/changelog.d/484.feature
+++ b/changelog.d/484.feature
@@ -1,0 +1,1 @@
+Add a per-app `forward_event_type_for_event_id_only` configuration option: when enabled, an `event_id_only`-shaped notification that carries the event `type` keeps the minimal payload (instead of being treated as full-format on APNs) and forwards the `type`, so that VoIP clients can recognise incoming calls without fetching the event.

--- a/sygnal.yaml.sample
+++ b/sygnal.yaml.sample
@@ -187,6 +187,13 @@ apps:
   #  # If the associated app supports encryption then this should probably be
   #  # false. Defaults to true.
   #
+  #  # If the homeserver includes the event `type` in an `event_id_only`-format
+  #  # notification, enabling this forwards it (and nothing else) instead of
+  #  # treating the notification as full-format; this lets VoIP clients report
+  #  # incoming calls to CallKit immediately, as Apple requires. Defaults to
+  #  # false.
+  #  #forward_event_type_for_event_id_only: true
+  #
   #  # This is the maximum number of in-flight requests *for this pushkin*
   #  # before additional notifications will be failed.
   #  # (This is a robustness measure to prevent one pushkin stacking up with
@@ -228,6 +235,12 @@ apps:
   #  # If the associated app supports encryption then this should probably be
   #  # false. Defaults to true.
   #  #send_badge_counts: false
+  #
+  #  # If the homeserver includes the event `type` in an `event_id_only`-format
+  #  # notification, enabling this forwards it (and nothing else); without it,
+  #  # the `type` of such a notification is dropped. This lets VoIP clients
+  #  # recognise incoming calls without fetching the event. Defaults to false.
+  #  #forward_event_type_for_event_id_only: true
   #
   #  # This is the maximum number of connections to GCM servers at any one time
   #  # the default is 20.

--- a/sygnal/apnspushkin.py
+++ b/sygnal/apnspushkin.py
@@ -107,6 +107,7 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
         "push_type",
         "convert_device_token_to_hex",
         "send_badge_counts",
+        "forward_event_type_for_event_id_only",
     } | ConcurrencyLimitedPushkin.UNDERSTOOD_CONFIG_FIELDS
 
     APNS_PUSH_TYPES = {
@@ -315,12 +316,25 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
                     return [device.pushkey]
 
             send_badge_counts = self.get_config("send_badge_counts", bool, True)
+            forward_event_type = self.get_config(
+                "forward_event_type_for_event_id_only", bool, False
+            )
 
-            if n.event_id and not n.type:
+            # An event_id_only-shaped notification normally carries no event
+            # `type`. Homeservers may be configured to include it anyway (e.g.
+            # so that a VoIP client can recognise an incoming call without
+            # fetching the event). With `forward_event_type_for_event_id_only`
+            # enabled, such a notification still takes the event_id_only path
+            # — forwarding the `type` — rather than being treated as a
+            # full-format notification.
+            if n.event_id and (
+                not n.type or (forward_event_type and n.is_event_id_only_shaped())
+            ):
                 payload: Optional[Dict[str, Any]] = self._get_payload_event_id_only(
                     n,
                     default_payload,
                     send_badge_counts,
+                    forward_event_type,
                 )
             else:
                 payload = self._get_payload_full(n, device, log, send_badge_counts)
@@ -390,6 +404,7 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
         n: Notification,
         default_payload: Dict[str, Any],
         send_badge_counts: bool,
+        forward_event_type: bool,
     ) -> Dict[str, Any]:
         """
         Constructs a payload for a notification where we know only the event ID.
@@ -398,6 +413,8 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
             device: Device information to which the constructed payload
             will be sent.
             send_badge_counts: if `True`, the `unread_count` and `missed_calls` fields will be included.
+            forward_event_type: if `True`, the event `type` will be included
+            when the notification carries one.
 
         Returns:
             The APNs payload as a nested dicts.
@@ -410,6 +427,8 @@ class ApnsPushkin(ConcurrencyLimitedPushkin):
             payload["room_id"] = n.room_id
         if n.event_id:
             payload["event_id"] = n.event_id
+        if forward_event_type and n.type:
+            payload["type"] = n.type
 
         if send_badge_counts:
             if n.counts.unread is not None:

--- a/sygnal/gcmpushkin.py
+++ b/sygnal/gcmpushkin.py
@@ -127,6 +127,7 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
         "project_id",
         "service_account_file",
         "send_badge_counts",
+        "forward_event_type_for_event_id_only",
     } | ConcurrencyLimitedPushkin.UNDERSTOOD_CONFIG_FIELDS
 
     def __init__(self, name: str, sygnal: "Sygnal", config: Dict[str, Any]) -> None:
@@ -540,8 +541,11 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
             failed: List[str] = []
 
             send_badge_counts = self.get_config("send_badge_counts", bool, True)
+            forward_event_type = self.get_config(
+                "forward_event_type_for_event_id_only", bool, False
+            )
             data = GcmPushkin._build_data(
-                n, device, self.api_version, send_badge_counts
+                n, device, self.api_version, send_badge_counts, forward_event_type
             )
 
             # Reject pushkey(s) if default_payload is misconfigured
@@ -659,6 +663,7 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
         device: Device,
         api_version: APIVersion,
         send_badge_counts: bool,
+        forward_event_type: bool,
     ) -> Optional[Dict[str, Any]]:
         """
         Build the payload data to be sent.
@@ -668,6 +673,9 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
             will be sent.
             api_version: API version used by Firebase/GCM.
             send_badge_counts: If set to `True`, will send the unread and missed_call counts.
+            forward_event_type: If set to `True`, the event `type` of an
+            event_id_only-shaped notification will be forwarded. Full-format
+            notifications always carry their `type`, regardless of this setting.
 
         Returns:
             JSON-compatible dict. The dict will be empty if the payload was
@@ -698,6 +706,16 @@ class GcmPushkin(ConcurrencyLimitedPushkin):
             "content",
             "room_id",
         ]:
+            if (
+                attr == "type"
+                and not forward_event_type
+                and n.is_event_id_only_shaped()
+            ):
+                # An event_id_only-shaped notification normally carries no
+                # `type`. Unless explicitly opted in, do not forward one:
+                # the event type is metadata the push service does not need
+                # to see.
+                continue
             if hasattr(n, attr):
                 current = getattr(n, attr)
                 if current is None:

--- a/sygnal/notifications.py
+++ b/sygnal/notifications.py
@@ -101,6 +101,27 @@ class Notification:
 
         self.devices = [Device(d) for d in notif["devices"]]
 
+    def is_event_id_only_shaped(self) -> bool:
+        """
+        Whether this notification is shaped like an `event_id_only`-format
+        notification: it carries an event ID, but none of the fields that
+        only a full-format notification carries (content, sender, room
+        name, …).
+
+        Such a notification may still carry the event `type`, e.g. when the
+        homeserver is configured to include it so that clients can recognise
+        incoming VoIP calls without fetching the event.
+        """
+        return (
+            self.event_id is not None
+            and self.content is None
+            and self.sender is None
+            and self.sender_display_name is None
+            and self.room_name is None
+            and self.room_alias is None
+            and self.membership is None
+        )
+
 
 class Pushkin(abc.ABC):
     def __init__(self, name: str, sygnal: "Sygnal", config: Dict[str, Any]):

--- a/tests/test_apns.py
+++ b/tests/test_apns.py
@@ -20,6 +20,7 @@ from tests import testutils
 PUSHKIN_ID = "com.example.apns"
 PUSHKIN_ID_WITHOUT_BADGES = "com.example.apns.disable_badges"
 PUSHKIN_ID_WITH_PUSH_TYPE = "com.example.apns.push_type"
+PUSHKIN_ID_FORWARD_TYPE = "com.example.apns.forward_type"
 
 TEST_CERTFILE_PATH = "/path/to/my/certfile.pem"
 
@@ -56,6 +57,12 @@ DEVICE_EXAMPLE_FOR_PUSH_TYPE_PUSHKIN = {
     "pushkey_ts": 42,
 }
 
+DEVICE_EXAMPLE_FOR_FORWARD_TYPE_PUSHKIN = {
+    "app_id": "com.example.apns.forward_type",
+    "pushkey": "spqr",
+    "pushkey_ts": 42,
+}
+
 
 class ApnsTestCase(testutils.TestCase):
     def setUp(self) -> None:
@@ -74,10 +81,12 @@ class ApnsTestCase(testutils.TestCase):
         self.apns_pushkin_snotif = MagicMock()
         test_pushkin = self.get_test_pushkin(PUSHKIN_ID)
         test_pushkin_push_type = self.get_test_pushkin(PUSHKIN_ID_WITH_PUSH_TYPE)
+        test_pushkin_forward_type = self.get_test_pushkin(PUSHKIN_ID_FORWARD_TYPE)
         # type safety: using ignore here due to mypy not handling monkeypatching,
         # see https://github.com/python/mypy/issues/2427
         test_pushkin._send_notification = self.apns_pushkin_snotif  # type: ignore[assignment] # noqa: E501
         test_pushkin_push_type._send_notification = self.apns_pushkin_snotif  # type: ignore[assignment] # noqa: E501
+        test_pushkin_forward_type._send_notification = self.apns_pushkin_snotif  # type: ignore[assignment] # noqa: E501
 
     def get_test_pushkin(self, name: str) -> ApnsPushkin:
         test_pushkin = self.sygnal.pushkins[name]
@@ -97,6 +106,12 @@ class ApnsTestCase(testutils.TestCase):
             "type": "apns",
             "certfile": TEST_CERTFILE_PATH,
             "push_type": "alert",
+        }
+        config["apps"][PUSHKIN_ID_FORWARD_TYPE] = {
+            "type": "apns",
+            "certfile": TEST_CERTFILE_PATH,
+            # This pusher is specifically testing that this field is `True`.
+            "forward_event_type_for_event_id_only": True,
         }
 
     def test_payload_truncation(self) -> None:
@@ -215,6 +230,153 @@ class ApnsTestCase(testutils.TestCase):
                 "aps": {
                     "alert": {"loc-key": "SINGLE_UNREAD", "loc-args": []},
                     "mutable-content": 1,
+                },
+            },
+            notification_req.message,
+        )
+
+        self.assertEqual({"rejected": []}, resp)
+
+    def test_event_id_only_with_type_default_off(self) -> None:
+        """
+        Tests that with `forward_event_type_for_event_id_only` unset, an
+        event_id_only-shaped notification carrying a `type` is treated as a
+        full-format notification, exactly as before the option existed.
+        """
+        # Arrange
+        method = self.apns_pushkin_snotif
+        method.side_effect = testutils.make_async_magic_mock(
+            NotificationResult("notID", "200")
+        )
+
+        # Act
+        resp = self._request(
+            self._make_dummy_notification_event_id_only_with_type([DEVICE_EXAMPLE])
+        )
+
+        # Assert
+        self.assertEqual(1, method.call_count)
+        ((notification_req,), _kwargs) = method.call_args
+
+        self.assertEqual(
+            {
+                "room_id": "!slw48wfj34rtnrf:example.com",
+                "event_id": "$qTOWWTEL48yPm3uT-gdNhFcoHxfKbZuqRVnnWWSkGBs",
+                "aps": {
+                    "alert": {
+                        "loc-key": "VOICE_CALL_FROM_USER",
+                        "loc-args": [" "],
+                    },
+                    "badge": 2,
+                },
+            },
+            notification_req.message,
+        )
+
+        self.assertEqual({"rejected": []}, resp)
+
+    def test_forward_event_type_for_event_id_only(self) -> None:
+        """
+        Tests that with `forward_event_type_for_event_id_only` enabled, an
+        event_id_only-shaped notification carrying a `type` keeps the minimal
+        payload, with the `type` included.
+        """
+        # Arrange
+        method = self.apns_pushkin_snotif
+        method.side_effect = testutils.make_async_magic_mock(
+            NotificationResult("notID", "200")
+        )
+
+        # Act
+        resp = self._request(
+            self._make_dummy_notification_event_id_only_with_type(
+                [DEVICE_EXAMPLE_FOR_FORWARD_TYPE_PUSHKIN]
+            )
+        )
+
+        # Assert
+        self.assertEqual(1, method.call_count)
+        ((notification_req,), _kwargs) = method.call_args
+
+        self.assertEqual(
+            {
+                "room_id": "!slw48wfj34rtnrf:example.com",
+                "event_id": "$qTOWWTEL48yPm3uT-gdNhFcoHxfKbZuqRVnnWWSkGBs",
+                "type": "m.call.invite",
+                "unread_count": 2,
+            },
+            notification_req.message,
+        )
+
+        self.assertEqual({"rejected": []}, resp)
+
+    def test_forward_event_type_for_event_id_only_without_type(self) -> None:
+        """
+        Tests that with `forward_event_type_for_event_id_only` enabled, an
+        event_id_only notification without a `type` is unchanged.
+        """
+        # Arrange
+        method = self.apns_pushkin_snotif
+        method.side_effect = testutils.make_async_magic_mock(
+            NotificationResult("notID", "200")
+        )
+
+        # Act
+        resp = self._request(
+            self._make_dummy_notification_event_id_only(
+                [DEVICE_EXAMPLE_FOR_FORWARD_TYPE_PUSHKIN]
+            )
+        )
+
+        # Assert
+        self.assertEqual(1, method.call_count)
+        ((notification_req,), _kwargs) = method.call_args
+
+        self.assertEqual(
+            {
+                "room_id": "!slw48wfj34rtnrf:example.com",
+                "event_id": "$qTOWWTEL48yPm3uT-gdNhFcoHxfKbZuqRVnnWWSkGBs",
+                "unread_count": 2,
+            },
+            notification_req.message,
+        )
+
+        self.assertEqual({"rejected": []}, resp)
+
+    def test_forward_event_type_full_notification_untouched(self) -> None:
+        """
+        Tests that `forward_event_type_for_event_id_only` does not change the
+        handling of a full-format notification.
+        """
+        # Arrange
+        method = self.apns_pushkin_snotif
+        method.side_effect = testutils.make_async_magic_mock(
+            NotificationResult("notID", "200")
+        )
+
+        # Act
+        resp = self._request(
+            self._make_dummy_notification([DEVICE_EXAMPLE_FOR_FORWARD_TYPE_PUSHKIN])
+        )
+
+        # Assert
+        self.assertEqual(1, method.call_count)
+        ((notification_req,), _kwargs) = method.call_args
+
+        self.assertEqual(
+            {
+                "room_id": "!slw48wfj34rtnrf:example.com",
+                "event_id": "$qTOWWTEL48yPm3uT-gdNhFcoHxfKbZuqRVnnWWSkGBs",
+                "aps": {
+                    "alert": {
+                        "loc-key": "MSG_FROM_USER_IN_ROOM_WITH_CONTENT",
+                        "loc-args": [
+                            "Major Tom",
+                            "Mission Control",
+                            "I'm floating in a most peculiar way.",
+                        ],
+                    },
+                    "badge": 3,
                 },
             },
             notification_req.message,

--- a/tests/test_gcm.py
+++ b/tests/test_gcm.py
@@ -168,6 +168,13 @@ class GcmTestCase(testutils.TestCase):
             # This pusher is specifically testing that this field is `False`.
             "send_badge_counts": False,
         }
+        config["apps"]["fcm-with-forwarded-event-type"] = {
+            "type": "tests.test_gcm.TestGcmPushkin",
+            "api_key": "kii",
+            "api_version": "legacy",
+            # This pusher is specifically testing that this field is `True`.
+            "forward_event_type_for_event_id_only": True,
+        }
         self.service_account_file = tempfile.NamedTemporaryFile()
         self.service_account_file.write(FAKE_SERVICE_ACCOUNT_FILE)
         self.service_account_file.flush()
@@ -220,6 +227,15 @@ class GcmTestCase(testutils.TestCase):
                     },
                 },
             },
+        }
+
+        config["apps"]["com.example.gcm.apiv1.forward-type"] = {
+            "type": "tests.test_gcm.TestGcmPushkin",
+            "api_version": "v1",
+            "project_id": "example_project",
+            "service_account_file": self.service_account_file.name,
+            # This pusher is specifically testing that this field is `True`.
+            "forward_event_type_for_event_id_only": True,
         }
 
     def tearDown(self) -> None:
@@ -776,6 +792,152 @@ class GcmTestCase(testutils.TestCase):
                 "event_id": "$qTOWWTEL48yPm3uT-gdNhFcoHxfKbZuqRVnnWWSkGBs",
                 "prio": "high",
                 "room_id": "!slw48wfj34rtnrf:example.com",
+            },
+        )
+
+    def test_event_id_only_with_type_default_off(self) -> None:
+        """
+        Tests that with `forward_event_type_for_event_id_only` unset, the
+        `type` of an event_id_only-shaped notification is not forwarded.
+        """
+        gcm = self.get_test_pushkin("com.example.gcm")
+        gcm.preload_with_response(
+            200, {"results": [{"message_id": "msg42", "registration_id": "spqr"}]}
+        )
+
+        resp = self._request(
+            self._make_dummy_notification_event_id_only_with_type([DEVICE_EXAMPLE])
+        )
+
+        self.assertEqual(resp, {"rejected": []})
+        assert gcm.last_request_body is not None
+
+        self.assertEqual(
+            gcm.last_request_body["data"],
+            {
+                "event_id": "$qTOWWTEL48yPm3uT-gdNhFcoHxfKbZuqRVnnWWSkGBs",
+                "prio": "high",
+                "room_id": "!slw48wfj34rtnrf:example.com",
+                "unread": 2,
+            },
+        )
+
+    def test_forward_event_type_for_event_id_only(self) -> None:
+        """
+        Tests that with `forward_event_type_for_event_id_only` enabled, the
+        `type` of an event_id_only-shaped notification is forwarded.
+        """
+        gcm = self.get_test_pushkin("fcm-with-forwarded-event-type")
+        gcm.preload_with_response(
+            200, {"results": [{"message_id": "msg42", "registration_id": "spqr"}]}
+        )
+
+        resp = self._request(
+            self._make_dummy_notification_event_id_only_with_type(
+                [
+                    {
+                        "app_id": "fcm-with-forwarded-event-type",
+                        "pushkey": "spqr",
+                        "pushkey_ts": 42,
+                    }
+                ]
+            )
+        )
+
+        self.assertEqual(resp, {"rejected": []})
+        assert gcm.last_request_body is not None
+
+        self.assertEqual(
+            gcm.last_request_body["data"],
+            {
+                "event_id": "$qTOWWTEL48yPm3uT-gdNhFcoHxfKbZuqRVnnWWSkGBs",
+                "type": "m.call.invite",
+                "prio": "high",
+                "room_id": "!slw48wfj34rtnrf:example.com",
+                "unread": 2,
+            },
+        )
+
+    def test_forward_event_type_for_event_id_only_api_v1(self) -> None:
+        """
+        Tests that with `forward_event_type_for_event_id_only` enabled in
+        API v1, the `type` of an event_id_only-shaped notification is
+        forwarded.
+        """
+        gcm = self.get_test_pushkin("com.example.gcm.apiv1.forward-type")
+        gcm.preload_with_response(
+            200, {"results": [{"message_id": "msg42", "registration_id": "spqr"}]}
+        )
+
+        resp = self._request(
+            self._make_dummy_notification_event_id_only_with_type(
+                [
+                    {
+                        "app_id": "com.example.gcm.apiv1.forward-type",
+                        "pushkey": "spqr",
+                        "pushkey_ts": 42,
+                    }
+                ]
+            )
+        )
+
+        self.assertEqual(resp, {"rejected": []})
+        assert gcm.last_request_body is not None
+
+        self.assertEqual(
+            gcm.last_request_body["message"]["data"],
+            {
+                "event_id": "$qTOWWTEL48yPm3uT-gdNhFcoHxfKbZuqRVnnWWSkGBs",
+                "type": "m.call.invite",
+                "prio": "high",
+                "room_id": "!slw48wfj34rtnrf:example.com",
+                "unread": "2",
+            },
+        )
+
+    def test_forward_event_type_full_notification_untouched(self) -> None:
+        """
+        Tests that `forward_event_type_for_event_id_only` does not change the
+        handling of a full-format notification.
+        """
+        gcm = self.get_test_pushkin("fcm-with-forwarded-event-type")
+        gcm.preload_with_response(
+            200, {"results": [{"message_id": "msg42", "registration_id": "spqr"}]}
+        )
+
+        resp = self._request(
+            self._make_dummy_notification(
+                [
+                    {
+                        "app_id": "fcm-with-forwarded-event-type",
+                        "pushkey": "spqr",
+                        "pushkey_ts": 42,
+                    }
+                ]
+            )
+        )
+
+        self.assertEqual(resp, {"rejected": []})
+        assert gcm.last_request_body is not None
+
+        self.assertEqual(
+            gcm.last_request_body["data"],
+            {
+                "event_id": "$qTOWWTEL48yPm3uT-gdNhFcoHxfKbZuqRVnnWWSkGBs",
+                "type": "m.room.message",
+                "sender": "@exampleuser:matrix.org",
+                "room_name": "Mission Control",
+                "room_alias": "#exampleroom:matrix.org",
+                "sender_display_name": "Major Tom",
+                "content": {
+                    "msgtype": "m.text",
+                    "body": "I'm floating in a most peculiar way.",
+                    "other": 1,
+                },
+                "room_id": "!slw48wfj34rtnrf:example.com",
+                "prio": "high",
+                "unread": 2,
+                "missed_calls": 1,
             },
         )
 

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -130,6 +130,16 @@ class TestCase(unittest.TestCase):
             }
         }
 
+    def _make_dummy_notification_event_id_only_with_type(self, devices):
+        """
+        An event_id_only-shaped notification which additionally carries the
+        event `type`, as a homeserver configured to do so would send it
+        (e.g. for VoIP call notifications).
+        """
+        notif = self._make_dummy_notification_event_id_only(devices)
+        notif["notification"]["type"] = "m.call.invite"
+        return notif
+
     def _make_dummy_notification_badge_only(self, devices):
         return {
             "notification": {


### PR DESCRIPTION
## Summary

Add a per-app boolean configuration option, `forward_event_type_for_event_id_only`
(default: `false`), to both the APNs and the GCM/FCM pushkins.

When enabled, a notification that is shaped like an `event_id_only`-format
notification but additionally carries the event `type`:

- keeps its minimal payload (`room_id`, `event_id`, counts, `default_payload`)
  instead of being treated as a full-format notification, and
- forwards the `type` — and nothing else — to the push service.

## Motivation: VoIP calls and CallKit

Apple requires VoIP calls received over PushKit to be reported to CallKit
**immediately**; an app that fails to do so is killed by the system. Clients
using `event_id_only` pushers (for privacy) receive pushes containing only the
event ID, so on an incoming call they must first fetch the event from the
homeserver before they can even tell it *is* a call — too slow and too fragile
for the CallKit deadline.

A homeserver can be configured to include the event `type` (e.g.
`m.call.invite`) in the notification it sends to the push gateway for
`event_id_only` pushers. Today that does not work end-to-end:

- **APNs**: the pushkin routes on `if n.event_id and not n.type`, so the mere
  presence of `type` diverts the notification to the full-format path, which
  builds display-name-based `loc-key`/`loc-args` strings — precisely what
  `event_id_only` exists to avoid.
- **GCM/FCM**: `_build_data` relays every field it receives, so the `type`
  would be forwarded to Google without the gateway operator having opted in.

With this option enabled, the client receives `{room_id, event_id, type}` and
can report the call to CallKit straight away, and can do the equivalent
type-based dispatch on Android/FCM.

### Scope: this does not help end-to-end encrypted rooms

Stating the boundary up front rather than leaving a reviewer to find it. In an
encrypted room every timeline event goes on the wire as `m.room.encrypted`, so
the `type` a homeserver can put in the notification is `m.room.encrypted` for a
call invite exactly as for a text message. This option therefore helps only
deployments where call signalling travels in cleartext rooms; in an
all-encrypted deployment it is inert.

For encrypted rooms the working pattern is the one Apple documents in [Sending
End-to-End Encrypted VoIP Calls][apple-e2ee]: the notification service
extension decrypts the event on the device and calls
`reportNewIncomingVoIPPushPayload`, so the gateway never needs to learn that a
call is a call. `docs/applications.md` in this repository states the same
constraint from the gateway's side, and has since 2021.

The CallKit motivation above is therefore real but bounded, and the option is
proposed on that narrower basis.

[apple-e2ee]: https://developer.apple.com/documentation/callkit/sending-end-to-end-encrypted-voip-calls

## Privacy

The event `type` is metadata, not content: it reveals the *kind* of event
(message, call invite, membership change), comparable to the `unread` and
`missed_calls` counts that pushers already carry. It contains no message body,
no sender name and no room name. The option is **opt-in and off by default**,
per application ID, so existing deployments are unaffected.

## Behaviour with the option off (default)

- **APNs**: byte-for-byte today's behaviour — an `event_id_only`-shaped
  notification carrying a `type` is treated as full-format (pinned by
  `test_event_id_only_with_type_default_off`, which passes against the
  unpatched code).
- **GCM/FCM**: the `type` of an `event_id_only`-shaped notification is now
  **dropped** instead of relayed. This is the one intentional behaviour
  change with the option off, and it is invisible to every existing
  deployment: no homeserver today includes a `type` in an
  `event_id_only`-format notification, so the shape it applies to does not
  occur in practice. Full-format notifications always keep their `type`,
  regardless of the option (pinned by existing tests and by
  `test_forward_event_type_full_notification_untouched`).

"event_id_only-shaped" is defined on the `Notification` object
(`Notification.is_event_id_only_shaped`): an event ID is present and none of
the fields only a full-format notification carries (`content`, `sender`,
`sender_display_name`, `room_name`, `room_alias`, `membership`) are present.

## Tests

Eight new tests in `tests/test_apns.py` and `tests/test_gcm.py`:

- option off: APNs routes to the full-format path exactly as today; GCM drops
  the `type`;
- option on: an `m.call.invite`-typed `event_id_only` notification keeps the
  minimal payload and forwards the `type` on both pushkins (GCM tested on both
  the legacy and the v1 FCM API);
- option on, plain `event_id_only` notification (no `type`): unchanged;
- option on, full-format notification: untouched.

Demonstration that the tests gate the behaviour: with `sygnal/` reverted to
`main`, the option-on tests fail (APNs builds `VOICE_CALL_FROM_USER` loc-keys;
GCM relayed the `type`), while the APNs option-off regression test still
passes.

Full suite: `Ran 69 tests … PASSED (successes=69)` (Python 3.11, twisted
trial).

The option is documented in `sygnal.yaml.sample` for both pushkins, and a
newsfragment is included (`changelog.d/484.feature`).

## Notes for reviewers

- This pairs with homeserver-side support for including `type` in
  `event_id_only` notifications; without it the option simply never sees a
  `type` to forward and is inert.

